### PR TITLE
LPS-122910

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/CTDisplayRendererRegistry.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/CTDisplayRendererRegistry.java
@@ -227,12 +227,6 @@ public class CTDisplayRendererRegistry {
 			ctCollectionId, ctSQLMode, ctEntry.getModelClassNameId(),
 			ctEntry.getModelClassPK());
 
-		if (model == null) {
-			return StringBundler.concat(
-				getTypeName(locale, ctEntry.getModelClassNameId()),
-				StringPool.SPACE, ctEntry.getModelClassPK());
-		}
-
 		return getTitle(
 			ctCollectionId, ctSQLMode, locale, model,
 			ctEntry.getModelClassNameId(), ctEntry.getModelClassPK());

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/CTDisplayRendererRegistry.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/CTDisplayRendererRegistry.java
@@ -235,9 +235,14 @@ public class CTDisplayRendererRegistry {
 
 		return getTitle(
 			ctCollectionId, ctSQLMode, locale, model,
-			ctEntry.getModelClassNameId());
+			ctEntry.getModelClassNameId(), ctEntry.getModelClassPK());
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #getTitle(long, CTSQLModeThreadLocal.CTSQLMode, Locale, T, long, long)}
+	 */
+	@Deprecated
 	public <T extends BaseModel<T>> String getTitle(
 		long ctCollectionId, CTSQLModeThreadLocal.CTSQLMode ctSQLMode,
 		Locale locale, T model, long modelClassNameId) {

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/CTDisplayRendererRegistry.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/CTDisplayRendererRegistry.java
@@ -279,6 +279,53 @@ public class CTDisplayRendererRegistry {
 			model.getPrimaryKeyObj());
 	}
 
+	public <T extends BaseModel<T>> String getTitle(
+		long ctCollectionId, CTSQLModeThreadLocal.CTSQLMode ctSQLMode,
+		Locale locale, T model, long modelClassNameId, long modelClassPK) {
+
+		if (model == null) {
+			return StringBundler.concat(
+				getTypeName(locale, modelClassNameId), StringPool.SPACE,
+				modelClassPK);
+		}
+
+		CTDisplayRenderer<T> ctDisplayRenderer =
+			(CTDisplayRenderer<T>)_ctDisplayServiceTrackerMap.getService(
+				modelClassNameId);
+
+		String name = null;
+
+		if (ctDisplayRenderer != null) {
+			try (SafeClosable safeClosable1 =
+					CTCollectionThreadLocal.setCTCollectionId(ctCollectionId);
+				SafeClosable safeClosable2 = CTSQLModeThreadLocal.setCTSQLMode(
+					ctSQLMode)) {
+
+				name = ctDisplayRenderer.getTitle(locale, model);
+			}
+			catch (PortalException portalException) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(portalException, portalException);
+				}
+
+				String typeName = ctDisplayRenderer.getTypeName(locale);
+
+				if (Validator.isNotNull(typeName)) {
+					return StringBundler.concat(
+						typeName, StringPool.SPACE, model.getPrimaryKeyObj());
+				}
+			}
+		}
+
+		if (Validator.isNotNull(name)) {
+			return name;
+		}
+
+		return StringBundler.concat(
+			getTypeName(locale, modelClassNameId), StringPool.SPACE,
+			model.getPrimaryKeyObj());
+	}
+
 	public <T extends BaseModel<T>> String getTypeName(
 		Locale locale, long modelClassNameId) {
 

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewChangesDisplayContext.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewChangesDisplayContext.java
@@ -741,7 +741,8 @@ public class ViewChangesDisplayContext {
 					_ctDisplayRendererRegistry.getTitle(
 						CTConstants.CT_COLLECTION_ID_PRODUCTION,
 						CTSQLModeThreadLocal.CTSQLMode.DEFAULT,
-						_themeDisplay.getLocale(), model, modelClassNameId)
+						_themeDisplay.getLocale(), model, modelClassNameId,
+						classPK)
 				);
 
 				modelInfo._site = _isSite(model);
@@ -809,7 +810,7 @@ public class ViewChangesDisplayContext {
 					"title",
 					_ctDisplayRendererRegistry.getTitle(
 						ctCollectionId, ctSQLMode, _themeDisplay.getLocale(),
-						model, modelClassNameId)
+						model, modelClassNameId, classPK)
 				).put(
 					"userId", ctEntry.getUserId()
 				);

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewConflictsDisplayContext.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewConflictsDisplayContext.java
@@ -293,26 +293,17 @@ public class ViewConflictsDisplayContext {
 			T model = _ctDisplayRendererRegistry.fetchCTModel(
 				modelClassNameId, conflictInfo.getTargetPrimaryKey());
 
-			String title = null;
-
-			if (model != null) {
-				title = _ctDisplayRendererRegistry.getTitle(
-					CTConstants.CT_COLLECTION_ID_PRODUCTION,
-					CTSQLModeThreadLocal.CTSQLMode.DEFAULT,
-					_themeDisplay.getLocale(), model, modelClassNameId,
-					conflictInfo.getTargetPrimaryKey());
-			}
-			else {
-				title = _ctDisplayRendererRegistry.getTypeName(
-					_themeDisplay.getLocale(), modelClassNameId);
-			}
-
 			jsonObject.put(
 				"description",
 				_ctDisplayRendererRegistry.getTypeName(
 					_themeDisplay.getLocale(), modelClassNameId)
 			).put(
-				"title", title
+				"title",
+				_ctDisplayRendererRegistry.getTitle(
+					CTConstants.CT_COLLECTION_ID_PRODUCTION,
+					CTSQLModeThreadLocal.CTSQLMode.DEFAULT,
+					_themeDisplay.getLocale(), model, modelClassNameId,
+					conflictInfo.getTargetPrimaryKey())
 			).put(
 				"viewURL",
 				_getViewURL(

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewConflictsDisplayContext.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewConflictsDisplayContext.java
@@ -299,7 +299,8 @@ public class ViewConflictsDisplayContext {
 				title = _ctDisplayRendererRegistry.getTitle(
 					CTConstants.CT_COLLECTION_ID_PRODUCTION,
 					CTSQLModeThreadLocal.CTSQLMode.DEFAULT,
-					_themeDisplay.getLocale(), model, modelClassNameId);
+					_themeDisplay.getLocale(), model, modelClassNameId,
+					conflictInfo.getTargetPrimaryKey());
 			}
 			else {
 				title = _ctDisplayRendererRegistry.getTypeName(


### PR DESCRIPTION
Hey @kevhlee,
Please take a look and test my changes, and let me know how it goes.

My thoughts were to have the getTitle methods be uniform across the board, since one called the other.  with your initial changes, we would have had 2-3 different outcomes anywhere the getTitle method was called (one for each method, and one more for the ViewConflictsDisplayContext class call, since it gives a different title for null title as well).  With my changes, I'm hoping everything is now uniform, as well as any future use of the get title method(s).

Also, I left the final commit as optional, as there may be some unique business logic there which requires a different title for null model.  This probably isn't the case, but if you can confirm I'd appreciate it.

Let me know what you think, thanks!

CC @wanderlast