### PR TITLE
LPS-147267 Fix logic for checking class name

### DIFF
--- a/modules/apps/friendly-url/test.properties
+++ b/modules/apps/friendly-url/test.properties
@@ -16,8 +16,8 @@
     test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][relevant]=\
         (portal.acceptance == true) AND \
         (\
-            (testray.main.component.name ~ "Friendly URL") OR \
-            (testray.main.component.name ~ "Friendly URL Service")\
+            (testray.main.component.name ~ "Friendly URL Service") OR \
+            (testray.main.component.name ~ "Friendly URL")\
         )
 
 ##

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/exception/ObjectFieldSettingValueException.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/exception/ObjectFieldSettingValueException.java
@@ -11,6 +11,7 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
+
 package com.liferay.object.exception;
 
 import com.liferay.portal.kernel.exception.PortalException;

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionUtilTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionUtilTest.java
@@ -164,8 +164,7 @@ public class DBPartitionUtilTest extends BaseDBPartitionTestCase {
 					Assert.assertEquals(
 						companyId, CompanyThreadLocal.getCompanyId());
 
-					Assert.assertEquals(
-						true, CompanyThreadLocal.isLocked());
+					Assert.assertTrue(CompanyThreadLocal.isLocked());
 
 					companyIds.add(companyId);
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/ResourceImplCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/ResourceImplCheck.java
@@ -39,7 +39,7 @@ public class ResourceImplCheck extends BaseCheck {
 
 		String className = getName(detailAST);
 
-		if (!className.endsWith("ResourceImpl") &&
+		if (!className.endsWith("ResourceImpl") ||
 			className.startsWith("Base")) {
 
 			return;


### PR DESCRIPTION
### 📝 Notes:

__Ticket:__
<https://issues.liferay.com/browse/LPS-147267>

Made a small mistake in the logic for checking the class name. Currently, it checks `Base*ResourceImpl.java` classes.