### PR TITLE
LPS-137720 Fix conditional logic

### DIFF
--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/upgrade/LoginWebUpgrade.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/upgrade/LoginWebUpgrade.java
@@ -32,7 +32,7 @@ public class LoginWebUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		registry.register("0.0.0", "1.0.0", new DummyUpgradeStep());
+		registry.register("0.0.0", "1.0.1", new DummyUpgradeStep());
 
 		registry.register("0.0.1", "1.0.0", new UpgradePortletId());
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaUpgradeVersionCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaUpgradeVersionCheck.java
@@ -253,10 +253,10 @@ public class JavaUpgradeVersionCheck extends BaseJavaTermCheck {
 
 			if ((parameterList.size() != 3) ||
 				!Objects.equals(parameterList.get(0), "\"0.0.0\"") ||
-				!Objects.equals(
+				!(Objects.equals(
 					parameterList.get(2), "new DummyUpgradeStep()") ||
-				!Objects.equals(
-					parameterList.get(2), "new DummyUpgradeProcess()")) {
+				  Objects.equals(
+					  parameterList.get(2), "new DummyUpgradeProcess()"))) {
 
 				return content;
 			}

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/JavaUpgradeVersionSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/JavaUpgradeVersionSourceProcessorTest.java
@@ -23,6 +23,11 @@ public class JavaUpgradeVersionSourceProcessorTest
 	extends BaseSourceProcessorTestCase {
 
 	@Test
+	public void testDummyUpgradeStepVersion() throws Exception {
+		test("DummyUpgradeStepVersion.testjava");
+	}
+
+	@Test
 	public void testMajorUpgradeByAlterColumnName() throws Exception {
 		test("MajorUpgradeByAlterColumnName.testjava", "2.0.0", 30);
 	}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/DummyUpgradeStepVersion.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/DummyUpgradeStepVersion.testjava
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.dependencies;
+
+import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Kevin Lee
+ */
+@Component(immediate = true, service = UpgradeStepRegistrator.class)
+public class DummyUpgradeStepVersion implements UpgradeStepRegistrator {
+
+	@Override
+	public void register(Registry registry) {
+		registry.register("0.0.0", "1.0.0", new DummyUpgradeStep());
+
+		registry.register(
+			"1.0.0", "1.1.0",
+			new UpgradeProcess() {
+
+				@Override
+				protected void doUpgrade() throws Exception {
+					alter(
+						DummyUpgradeStepVersion.class,
+						new AlterTableAddColumn("test LONG"));
+				}
+
+			});
+
+		registry.register(
+			"1.1.0", "1.1.1", new DummyUpgradeStep(), new DummyUpgradeStep());
+	}
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/DummyUpgradeStepVersion.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/DummyUpgradeStepVersion.testjava
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.dependencies;
+
+import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Kevin Lee
+ */
+@Component(immediate = true, service = UpgradeStepRegistrator.class)
+public class DummyUpgradeStepVersion implements UpgradeStepRegistrator {
+
+	@Override
+	public void register(Registry registry) {
+		registry.register("0.0.0", "1.1.1", new DummyUpgradeStep());
+
+		registry.register(
+			"1.0.0", "1.1.0",
+			new UpgradeProcess() {
+
+				@Override
+				protected void doUpgrade() throws Exception {
+					alter(
+						DummyUpgradeStepVersion.class,
+						new AlterTableAddColumn("test LONG"));
+				}
+
+			});
+
+		registry.register(
+			"1.1.0", "1.1.1", new DummyUpgradeStep(), new DummyUpgradeStep());
+	}
+
+}


### PR DESCRIPTION
### 📝 Notes

__Ticket:__
<https://issues.liferay.com/browse/LPS-137720>

Currently, `JavaUpgradeVersionCheck` does not work in fixing the initial upgrade step version for web module upgrades, as seen in this pull request: <https://github.com/liferay-upgrades/liferay-portal/pull/302#discussion_r825490151>. This pull request fixes `JavaUpgradeVersionCheck` and adds a unit test to ensure this doesn't occur in the future.

Let me know if you have any questions.