### PR TITLE
LPS-153072 Create SF rule to replace unnecessary Gradle dependencies with "release.dxp.api"

### DIFF
--- a/modules/apps/commerce/commerce-shipment-web/package.json
+++ b/modules/apps/commerce/commerce-shipment-web/package.json
@@ -7,5 +7,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "4.0.26"
+	"version": "4.0.27"
 }

--- a/modules/util/source-formatter/build.gradle
+++ b/modules/util/source-formatter/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	compileInclude group: "com.liferay", name: "com.liferay.petra.nio", version: "1.0.0"
 	compileInclude group: "com.liferay", name: "com.liferay.petra.string", version: "2.0.0"
 	compileInclude group: "com.liferay", name: "com.liferay.poshi.core", version: "1.0.65"
+	compileInclude group: "org.codehaus.groovy", name: "groovy", version: "2.4.21"
 
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
 	compileOnly group: "com.liferay", name: "com.liferay.petra.concurrent", version: "1.1.0"

--- a/modules/util/source-formatter/source-formatter.properties
+++ b/modules/util/source-formatter/source-formatter.properties
@@ -10,6 +10,9 @@
 
     checkstyle.ExceptionMapperAnnotationCheck.enabled=true
 
+    checkstyle.ChainingCheck.allowedClassNames=\
+        Comparator
+
     source.check.JavaClassNameCheck.enabled=false
 
     source.check.JavaCollapseImportsCheck.jarDirectoryName=src/test/resources

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/GradleUpgradeReleaseDXPCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/GradleUpgradeReleaseDXPCheck.java
@@ -14,6 +14,30 @@
 
 package com.liferay.source.formatter.check;
 
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.servlet.HttpMethods;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.source.formatter.check.util.SourceUtil;
+import com.liferay.source.formatter.util.SourceFormatterUtil;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.dom4j.Document;
+import org.dom4j.DocumentException;
+import org.dom4j.Element;
+
 /**
  * @author Kevin Lee
  */
@@ -24,7 +48,114 @@ public class GradleUpgradeReleaseDXPCheck extends BaseFileCheck {
 			String fileName, String absolutePath, String content)
 		throws Exception {
 
+		String upgradeToVersion = getAttributeValue(
+			SourceFormatterUtil.UPGRADE_TO_VERSION, absolutePath);
+
+		if (Validator.isNull(upgradeToVersion)) {
+			return content;
+		}
+
+		return _formatDependencies(content, upgradeToVersion);
+	}
+
+	private String _formatDependencies(
+		String content, String upgradeToVersion) {
+
+		Map<String, Set<String>> releaseDXPDependencies =
+			_getReleaseDXPDependencies(upgradeToVersion);
+
+		if (releaseDXPDependencies == null) {
+			return content;
+		}
+
 		return content;
 	}
+
+	private Map<String, Set<String>> _getReleaseDXPDependencies(
+		String upgradeToVersion) {
+
+		if (Objects.equals(upgradeToVersion, _upgradeToVersion)) {
+			return _releaseDXPDependencies;
+		}
+
+		try {
+			URL url = new URL(_getReleaseDXPPomURL(upgradeToVersion));
+
+			HttpURLConnection httpURLConnection =
+				(HttpURLConnection)url.openConnection();
+
+			httpURLConnection.setConnectTimeout(10000);
+			httpURLConnection.setReadTimeout(10000);
+			httpURLConnection.setRequestMethod(HttpMethods.GET);
+
+			String content = StringUtil.read(
+				httpURLConnection.getInputStream());
+
+			if (Objects.equals(content, StringPool.BLANK)) {
+				return null;
+			}
+
+			_upgradeToVersion = upgradeToVersion;
+			_releaseDXPDependencies = _readReleaseDXPDependencies(content);
+		}
+		catch (Exception exception) {
+			_log.error(exception);
+
+			return null;
+		}
+
+		return _releaseDXPDependencies;
+	}
+
+	private String _getReleaseDXPPomURL(String upgradeToVersion) {
+		String baseURL =
+			"https://repository-cdn.liferay.com/nexus/content/repositories" +
+				"/liferay-public-releases/com/liferay/portal/release.dxp.bom/";
+
+		return StringBundler.concat(
+			baseURL, upgradeToVersion, "/release.dxp.bom-", upgradeToVersion,
+			".pom");
+	}
+
+	private Map<String, Set<String>> _readReleaseDXPDependencies(String content)
+		throws DocumentException {
+
+		Document document = SourceUtil.readXML(content);
+
+		Element rootElement = document.getRootElement();
+
+		Element dependencyManagementElement = rootElement.element(
+			"dependencyManagement");
+
+		Element dependenciesElement = dependencyManagementElement.element(
+			"dependencies");
+
+		List<Element> dependencyElements = dependenciesElement.elements(
+			"dependency");
+
+		Map<String, Set<String>> dependencies = new HashMap<>();
+
+		for (Element dependencyElement : dependencyElements) {
+			Element groupIdElement = dependencyElement.element("groupId");
+			Element artifactIdElement = dependencyElement.element("artifactId");
+
+			String groupId = groupIdElement.getText();
+			String artifactId = artifactIdElement.getText();
+
+			dependencies.putIfAbsent(groupId, new HashSet<>());
+
+			Set<String> artifactIds = dependencies.get(groupId);
+
+			artifactIds.add(artifactId);
+		}
+
+		return dependencies;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		GradleUpgradeReleaseDXPCheck.class);
+
+	private Map<String, Set<String>> _releaseDXPDependencies;
+	private String _upgradeToVersion;
 
 }

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/GradleUpgradeReleaseDXPCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/GradleUpgradeReleaseDXPCheck.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.check;
+
+/**
+ * @author Kevin Lee
+ */
+public class GradleUpgradeReleaseDXPCheck extends BaseFileCheck {
+
+	@Override
+	protected String doProcess(
+			String fileName, String absolutePath, String content)
+		throws Exception {
+
+		return content;
+	}
+
+}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/GradleUpgradeReleaseDxpCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/GradleUpgradeReleaseDxpCheck.java
@@ -51,10 +51,6 @@ public class GradleUpgradeReleaseDxpCheck extends BaseFileCheck {
 			String fileName, String absolutePath, String content)
 		throws Exception {
 
-		if (!fileName.endsWith("build.gradle")) {
-			return content;
-		}
-
 		String upgradeToVersion = getAttributeValue(
 			SourceFormatterUtil.UPGRADE_TO_VERSION, absolutePath);
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/GradleUpgradeReleaseDxpCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/GradleUpgradeReleaseDxpCheck.java
@@ -115,12 +115,14 @@ public class GradleUpgradeReleaseDxpCheck extends BaseFileCheck {
 
 		if (hasCompile) {
 			buildFile.insertDependency(
-				"compileOnly", "com.liferay.portal", "release.dxp.api");
+				"compileOnly", "com.liferay.portal", "release.dxp.api",
+				upgradeToVersion);
 		}
 
 		if (hasTest) {
 			buildFile.insertDependency(
-				"testCompile", "com.liferay.portal", "release.dxp.api");
+				"testCompile", "com.liferay.portal", "release.dxp.api",
+				upgradeToVersion);
 		}
 
 		return buildFile.getSource();

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/GradleUpgradeReleaseDxpCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/GradleUpgradeReleaseDxpCheck.java
@@ -44,7 +44,7 @@ import org.dom4j.Element;
 /**
  * @author Kevin Lee
  */
-public class GradleUpgradeReleaseDXPCheck extends BaseFileCheck {
+public class GradleUpgradeReleaseDxpCheck extends BaseFileCheck {
 
 	@Override
 	protected String doProcess(
@@ -208,7 +208,7 @@ public class GradleUpgradeReleaseDXPCheck extends BaseFileCheck {
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
-		GradleUpgradeReleaseDXPCheck.class);
+		GradleUpgradeReleaseDxpCheck.class);
 
 	private Map<String, Set<String>> _releaseDXPDependencies;
 	private String _upgradeToVersion;

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/upgrade/GradleBuildFile.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/upgrade/GradleBuildFile.java
@@ -1,0 +1,191 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.upgrade;
+
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.builder.AstBuilder;
+import org.codehaus.groovy.control.CompilePhase;
+
+/**
+ * @author Kevin Lee
+ */
+public class GradleBuildFile {
+
+	public GradleBuildFile(String source) {
+		_source = source;
+	}
+
+	public void deleteDependencies(List<GradleDependency> dependencies) {
+		List<String> lines = getSourceLines();
+
+		dependencies.sort(GradleDependency.COMPARATOR_LAST_LINE_NUMBER_DESC);
+
+		for (GradleDependency dependency : dependencies) {
+			int lineNumber = dependency.getLineNumber();
+			int lastLineNumber = dependency.getLastLineNumber();
+
+			for (int i = lastLineNumber; i >= lineNumber; i--) {
+				lines.remove(i - 1);
+			}
+		}
+
+		_saveSource(lines);
+	}
+
+	public void deleteDependency(String group, String name) {
+		deleteDependency(null, group, name);
+	}
+
+	public void deleteDependency(
+		String configuration, String group, String name) {
+
+		List<GradleDependency> dependencies = getDependencies();
+
+		ListIterator<GradleDependency> listIterator = dependencies.listIterator(
+			dependencies.size());
+
+		List<String> lines = getSourceLines();
+
+		while (listIterator.hasPrevious()) {
+			GradleDependency dependency = listIterator.previous();
+
+			if ((configuration != null) &&
+				!Objects.equals(configuration, dependency.getConfiguration())) {
+
+				continue;
+			}
+
+			if (Objects.equals(group, dependency.getGroup()) &&
+				Objects.equals(name, dependency.getName())) {
+
+				for (int i = dependency.getLastLineNumber();
+					 i >= dependency.getLineNumber(); i--) {
+
+					lines.remove(i - 1);
+				}
+			}
+		}
+
+		_saveSource(lines);
+	}
+
+	public List<GradleDependency> getDependencies() {
+		GradleBuildFileVisitor buildFileVisitor = _walkAST();
+
+		return buildFileVisitor.getDependencies();
+	}
+
+	public List<GradleDependency> getDependencies(String configuration) {
+		GradleBuildFileVisitor buildFileVisitor = _walkAST();
+
+		List<GradleDependency> dependencies =
+			buildFileVisitor.getDependencies();
+
+		Stream<GradleDependency> stream = dependencies.stream();
+
+		return stream.filter(
+			dependency -> Objects.equals(
+				configuration, dependency.getConfiguration())
+		).collect(
+			Collectors.toList()
+		);
+	}
+
+	public String getSource() {
+		return _source;
+	}
+
+	public List<String> getSourceLines() {
+		return Stream.of(
+			_source.split(System.lineSeparator())
+		).collect(
+			Collectors.toList()
+		);
+	}
+
+	public void insertDependency(GradleDependency dependency) {
+		GradleBuildFileVisitor buildFileVisitor = _walkAST();
+
+		for (GradleDependency dep : buildFileVisitor.getDependencies()) {
+			if (dep.equals(dependency)) {
+				return;
+			}
+		}
+
+		List<String> lines = getSourceLines();
+
+		int dependencyLastLineNumber =
+			buildFileVisitor.getDependenciesLastLineNumber();
+
+		if (dependencyLastLineNumber == -1) {
+			lines.add("");
+			lines.add("dependencies {");
+			lines.add("\t" + dependency.toString());
+			lines.add("}");
+		}
+		else {
+			lines.add(
+				dependencyLastLineNumber - 1, "\t" + dependency.toString());
+		}
+
+		_saveSource(lines);
+	}
+
+	public void insertDependency(
+		String configuration, String group, String name) {
+
+		insertDependency(configuration, group, name, null);
+	}
+
+	public void insertDependency(
+		String configuration, String group, String name, String version) {
+
+		insertDependency(
+			new GradleDependency(configuration, group, name, version));
+	}
+
+	private void _saveSource(List<String> lines) {
+		Stream<String> stream = lines.stream();
+
+		_source = stream.collect(Collectors.joining(System.lineSeparator()));
+	}
+
+	private GradleBuildFileVisitor _walkAST() {
+		AstBuilder astBuilder = new AstBuilder();
+		GradleBuildFileVisitor buildFileVisitor = new GradleBuildFileVisitor();
+
+		for (ASTNode astNode :
+				astBuilder.buildFromString(CompilePhase.CONVERSION, _source)) {
+
+			if (astNode instanceof ClassNode) {
+				continue;
+			}
+
+			astNode.visit(buildFileVisitor);
+		}
+
+		return buildFileVisitor;
+	}
+
+	private String _source;
+
+}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/upgrade/GradleBuildFileVisitor.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/upgrade/GradleBuildFileVisitor.java
@@ -1,0 +1,184 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.upgrade;
+
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.codehaus.groovy.ast.CodeVisitorSupport;
+import org.codehaus.groovy.ast.expr.ArgumentListExpression;
+import org.codehaus.groovy.ast.expr.ConstantExpression;
+import org.codehaus.groovy.ast.expr.Expression;
+import org.codehaus.groovy.ast.expr.MapEntryExpression;
+import org.codehaus.groovy.ast.expr.MapExpression;
+import org.codehaus.groovy.ast.expr.MethodCallExpression;
+import org.codehaus.groovy.ast.stmt.BlockStatement;
+
+/**
+ * @author Kevin Lee
+ */
+public class GradleBuildFileVisitor extends CodeVisitorSupport {
+
+	public List<GradleDependency> getDependencies() {
+		return _dependencies;
+	}
+
+	public int getDependenciesLastLineNumber() {
+		return _dependenciesLastLineNumber;
+	}
+
+	public int getDependenciesLineNumber() {
+		return _dependenciesLineNumber;
+	}
+
+	@Override
+	public void visitArgumentlistExpression(
+		ArgumentListExpression argumentListExpression) {
+
+		if (!_inDependencies) {
+			return;
+		}
+
+		List<Expression> expressions = argumentListExpression.getExpressions();
+
+		if ((expressions.size() == 1) &&
+			(expressions.get(0) instanceof ConstantExpression)) {
+
+			ConstantExpression constantExpression =
+				(ConstantExpression)expressions.get(0);
+
+			String text = constantExpression.getText();
+
+			String[] parts = text.split(":");
+
+			if (parts.length >= 3) {
+				GradleDependency dependency = new GradleDependency(
+					_configuration, parts[0], parts[1], parts[2],
+					_methodCallLineNumber, _methodCallLastLineNumber);
+
+				_dependencies.add(dependency);
+			}
+		}
+
+		super.visitArgumentlistExpression(argumentListExpression);
+	}
+
+	@Override
+	public void visitBlockStatement(BlockStatement blockStatement) {
+		if (_inDependencies) {
+			_numberOfBlocks++;
+
+			super.visitBlockStatement(blockStatement);
+
+			_numberOfBlocks--;
+		}
+		else {
+			super.visitBlockStatement(blockStatement);
+		}
+	}
+
+	@Override
+	public void visitMapExpression(MapExpression mapExpression) {
+		if (!_inDependencies) {
+			return;
+		}
+
+		Map<String, String> keyValues = new HashMap<>();
+
+		boolean gav = false;
+
+		for (MapEntryExpression mapEntryExpression :
+				mapExpression.getMapEntryExpressions()) {
+
+			Expression keyExpression = mapEntryExpression.getKeyExpression();
+			Expression valueExpression =
+				mapEntryExpression.getValueExpression();
+
+			String key = keyExpression.getText();
+			String value = valueExpression.getText();
+
+			if (StringUtil.equalsIgnoreCase(key, "group")) {
+				gav = true;
+			}
+
+			keyValues.put(key, value);
+		}
+
+		if (gav) {
+			GradleDependency dependency = new GradleDependency(
+				_configuration, keyValues.get("group"), keyValues.get("name"),
+				keyValues.get("version"), _methodCallLineNumber,
+				_methodCallLastLineNumber);
+
+			_dependencies.add(dependency);
+		}
+
+		super.visitMapExpression(mapExpression);
+	}
+
+	@Override
+	public void visitMethodCallExpression(
+		MethodCallExpression methodCallExpression) {
+
+		_methodCallLineNumber = methodCallExpression.getLineNumber();
+		_methodCallLastLineNumber = methodCallExpression.getLastLineNumber();
+
+		if (_methodCallLineNumber > _dependenciesLastLineNumber) {
+			_inDependencies = false;
+		}
+
+		String methodName = methodCallExpression.getMethodAsString();
+
+		if (methodName.equals("dependencies")) {
+			_inDependencies = true;
+			_dependenciesLineNumber = methodCallExpression.getLineNumber();
+			_dependenciesLastLineNumber =
+				methodCallExpression.getLastLineNumber();
+		}
+
+		if (_inDependencies && (_numberOfBlocks > 0)) {
+			if (_numberOfBlocks > 1) {
+
+				// Assume all dependencies are initialized within the first
+				// level of "dependencies" block
+
+				return;
+			}
+
+			_configuration = methodName;
+
+			super.visitMethodCallExpression(methodCallExpression);
+
+			_configuration = null;
+		}
+		else {
+			super.visitMethodCallExpression(methodCallExpression);
+		}
+	}
+
+	private String _configuration;
+	private final List<GradleDependency> _dependencies = new ArrayList<>();
+	private int _dependenciesLastLineNumber = -1;
+	private int _dependenciesLineNumber = -1;
+	private boolean _inDependencies;
+	private int _methodCallLastLineNumber = -1;
+	private int _methodCallLineNumber = -1;
+	private int _numberOfBlocks;
+
+}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/upgrade/GradleDependency.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/upgrade/GradleDependency.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.upgrade;
+
+import java.text.MessageFormat;
+
+import java.util.Comparator;
+import java.util.Objects;
+
+/**
+ * @author Kevin Lee
+ */
+public class GradleDependency implements Comparable<GradleDependency> {
+
+	public static final Comparator<GradleDependency>
+		COMPARATOR_LAST_LINE_NUMBER_DESC = Comparator.comparingInt(
+			GradleDependency::getLastLineNumber
+		).reversed();
+
+	public GradleDependency(
+		String configuration, String group, String name, String version) {
+
+		this(configuration, group, name, version, -1, -1);
+	}
+
+	public GradleDependency(
+		String configuration, String group, String name, String version,
+		int lineNumber, int lastLineNumber) {
+
+		_configuration = configuration;
+		_group = group;
+		_name = name;
+		_version = version;
+		_lineNumber = lineNumber;
+		_lastLineNumber = lastLineNumber;
+	}
+
+	@Override
+	public int compareTo(GradleDependency dependency) {
+		String str = toString();
+
+		return str.compareTo(dependency.toString());
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof GradleDependency)) {
+			return false;
+		}
+
+		GradleDependency other = (GradleDependency)object;
+
+		if (Objects.equals(_configuration, other._configuration) &&
+			Objects.equals(_group, other._group) &&
+			Objects.equals(_name, other._name)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	public String getConfiguration() {
+		return _configuration;
+	}
+
+	public String getGroup() {
+		return _group;
+	}
+
+	public int getLastLineNumber() {
+		return _lastLineNumber;
+	}
+
+	public int getLineNumber() {
+		return _lineNumber;
+	}
+
+	public String getName() {
+		return _name;
+	}
+
+	public String getVersion() {
+		return _version;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(_configuration, _group, _name);
+	}
+
+	@Override
+	public String toString() {
+		if (_version == null) {
+			return MessageFormat.format(
+				"{0} group: \"{1}\", name: \"{2}\"", _configuration, _group,
+				_name);
+		}
+
+		return MessageFormat.format(
+			"{0} group: \"{1}\", name: \"{2}\", version: \"{3}\"",
+			_configuration, _group, _name, _version);
+	}
+
+	private final String _configuration;
+	private final String _group;
+	private final int _lastLineNumber;
+	private final int _lineNumber;
+	private final String _name;
+	private final String _version;
+
+}

--- a/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
@@ -102,7 +102,7 @@ GradleProvidedDependenciesCheck | [Bug Prevention](bug_prevention_checks.markdow
 GradleStylingCheck | [Styling](styling_checks.markdown#styling-checks) | .gradle | Applies rules to enforce consistency in code style. |
 [GradleTaskCreationCheck](check/gradle_task_creation_check.markdown#gradletaskcreationcheck) | [Styling](styling_checks.markdown#styling-checks) | .gradle | Checks that a task is declared on a separate line before the closure. |
 GradleTestDependencyVersionCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .gradle | Checks the version for dependencies in gradle build files. |
-GradleUpgradeReleaseDxpCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | .gradle | Remove and replaced dependencies in `build.gradle` that are already in `release.dxp.api` with `released.dxp.api` dependency. |
+[GradleUpgradeReleaseDxpCheck](check/gradle_upgrade_release_dxp_check.markdown#gradleupgradereleasedxpcheck) | [Upgrade](upgrade_checks.markdown#upgrade-checks) | .gradle | Remove and replaced dependencies in `build.gradle` that are already in `release.dxp.api` with `released.dxp.api` dependency. |
 GroovyImportsCheck | [Styling](styling_checks.markdown#styling-checks) | .groovy | Sorts and groups imports in `.groovy` files. |
 HTMLEmptyLinesCheck | [Styling](styling_checks.markdown#styling-checks) | .html or .path | Finds missing and unnecessary empty lines. |
 HTMLWhitespaceCheck | [Styling](styling_checks.markdown#styling-checks) | .html or .path | Finds missing and unnecessary whitespace in `.html` files. |

--- a/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
@@ -102,7 +102,7 @@ GradleProvidedDependenciesCheck | [Bug Prevention](bug_prevention_checks.markdow
 GradleStylingCheck | [Styling](styling_checks.markdown#styling-checks) | .gradle | Applies rules to enforce consistency in code style. |
 [GradleTaskCreationCheck](check/gradle_task_creation_check.markdown#gradletaskcreationcheck) | [Styling](styling_checks.markdown#styling-checks) | .gradle | Checks that a task is declared on a separate line before the closure. |
 GradleTestDependencyVersionCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .gradle | Checks the version for dependencies in gradle build files. |
-GradleUpgradeReleaseDXPCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | .gradle | Remove and replaced dependencies in `build.gradle` that are already in `release.dxp.api` with `released.dxp.api` dependency. |
+GradleUpgradeReleaseDxpCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | .gradle | Remove and replaced dependencies in `build.gradle` that are already in `release.dxp.api` with `released.dxp.api` dependency. |
 GroovyImportsCheck | [Styling](styling_checks.markdown#styling-checks) | .groovy | Sorts and groups imports in `.groovy` files. |
 HTMLEmptyLinesCheck | [Styling](styling_checks.markdown#styling-checks) | .html or .path | Finds missing and unnecessary empty lines. |
 HTMLWhitespaceCheck | [Styling](styling_checks.markdown#styling-checks) | .html or .path | Finds missing and unnecessary whitespace in `.html` files. |

--- a/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
@@ -102,6 +102,7 @@ GradleProvidedDependenciesCheck | [Bug Prevention](bug_prevention_checks.markdow
 GradleStylingCheck | [Styling](styling_checks.markdown#styling-checks) | .gradle | Applies rules to enforce consistency in code style. |
 [GradleTaskCreationCheck](check/gradle_task_creation_check.markdown#gradletaskcreationcheck) | [Styling](styling_checks.markdown#styling-checks) | .gradle | Checks that a task is declared on a separate line before the closure. |
 GradleTestDependencyVersionCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .gradle | Checks the version for dependencies in gradle build files. |
+GradleUpgradeReleaseDXPCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | .gradle | Remove and replaced dependencies in `build.gradle` that are already in `release.dxp.api` with `released.dxp.api` dependency. |
 GroovyImportsCheck | [Styling](styling_checks.markdown#styling-checks) | .groovy | Sorts and groups imports in `.groovy` files. |
 HTMLEmptyLinesCheck | [Styling](styling_checks.markdown#styling-checks) | .html or .path | Finds missing and unnecessary empty lines. |
 HTMLWhitespaceCheck | [Styling](styling_checks.markdown#styling-checks) | .html or .path | Finds missing and unnecessary whitespace in `.html` files. |

--- a/modules/util/source-formatter/src/main/resources/documentation/check/gradle_upgrade_release_dxp_check.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/check/gradle_upgrade_release_dxp_check.markdown
@@ -1,0 +1,45 @@
+## GradleUpgradeReleaseDxpCheck
+
+All dependencies in a `build.gradle` that are already contained in a specific
+version of the release DXP fat JAR should be removed and replaced by the
+dependency `release.dxp.api`. This applies to test dependencies as well.
+
+### Example
+
+Upgrade DXP version: `7.4.13.u20`
+
+Incorrect:
+
+```groovy
+dependencies {
+    compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.5.0"
+    compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "3.0.0"
+    compileOnly group: "org.osgi", name: "org.osgi.core", version: "6.0.0"
+
+    testCompile group: "com.liferay", name: "com.liferay.journal.api", version: "3.0.2"
+    testCompile group: 'com.liferay', name: 'com.liferay.dynamic.data.mapping.api', version: '4.8.3'
+    testCompile group: 'com.liferay', name: 'com.liferay.petra.lang', version: '3.0.0'
+    testCompile group: 'com.liferay', name: 'com.liferay.registry.api', version: '2.1.3'
+    testCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "3.6.2"
+    testCompile group: "org.mockito", name: "mockito-core", version: "2.8.47"
+    testCompile group: "javax.portlet", name: "portlet-api", version: "2.0"
+    testCompile group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
+    testCompile group: "junit", name: "junit", version: "4.12"
+    testCompile group: "org.powermock", name: "powermock-api-mockito2", version: "1.7.3"
+    testCompile group: "org.powermock", name: "powermock-module-junit4", version: "1.7.3"
+}
+```
+
+Correct:
+
+```groovy
+dependencies {
+    compileOnly group: "com.liferay.portal", name: "release.dxp.api", version: "7.4.13.u20"
+
+    testCompile group: "com.liferay.portal", name: "release.dxp.api", version: "7.4.13.u20"
+    testCompile group: "org.mockito", name: "mockito-core", version: "2.8.47"
+    testCompile group: "junit", name: "junit", version: "4.12"
+    testCompile group: "org.powermock", name: "powermock-api-mockito2", version: "1.7.3"
+    testCompile group: "org.powermock", name: "powermock-module-junit4", version: "1.7.3"
+}
+```

--- a/modules/util/source-formatter/src/main/resources/documentation/gradle_source_processor_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/gradle_source_processor_checks.markdown
@@ -18,4 +18,5 @@ GradleProvidedDependenciesCheck | [Bug Prevention](bug_prevention_checks.markdow
 GradleStylingCheck | [Styling](styling_checks.markdown#styling-checks) | Applies rules to enforce consistency in code style. |
 [GradleTaskCreationCheck](check/gradle_task_creation_check.markdown#gradletaskcreationcheck) | [Styling](styling_checks.markdown#styling-checks) | Checks that a task is declared on a separate line before the closure. |
 GradleTestDependencyVersionCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Checks the version for dependencies in gradle build files. |
+GradleUpgradeReleaseDXPCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | Remove and replaced dependencies in `build.gradle` that are already in `release.dxp.api` with `released.dxp.api` dependency. |
 WhitespaceCheck | [Styling](styling_checks.markdown#styling-checks) | Finds missing and unnecessary whitespace. |

--- a/modules/util/source-formatter/src/main/resources/documentation/gradle_source_processor_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/gradle_source_processor_checks.markdown
@@ -18,5 +18,5 @@ GradleProvidedDependenciesCheck | [Bug Prevention](bug_prevention_checks.markdow
 GradleStylingCheck | [Styling](styling_checks.markdown#styling-checks) | Applies rules to enforce consistency in code style. |
 [GradleTaskCreationCheck](check/gradle_task_creation_check.markdown#gradletaskcreationcheck) | [Styling](styling_checks.markdown#styling-checks) | Checks that a task is declared on a separate line before the closure. |
 GradleTestDependencyVersionCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Checks the version for dependencies in gradle build files. |
-GradleUpgradeReleaseDXPCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | Remove and replaced dependencies in `build.gradle` that are already in `release.dxp.api` with `released.dxp.api` dependency. |
+GradleUpgradeReleaseDxpCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | Remove and replaced dependencies in `build.gradle` that are already in `release.dxp.api` with `released.dxp.api` dependency. |
 WhitespaceCheck | [Styling](styling_checks.markdown#styling-checks) | Finds missing and unnecessary whitespace. |

--- a/modules/util/source-formatter/src/main/resources/documentation/gradle_source_processor_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/gradle_source_processor_checks.markdown
@@ -18,5 +18,5 @@ GradleProvidedDependenciesCheck | [Bug Prevention](bug_prevention_checks.markdow
 GradleStylingCheck | [Styling](styling_checks.markdown#styling-checks) | Applies rules to enforce consistency in code style. |
 [GradleTaskCreationCheck](check/gradle_task_creation_check.markdown#gradletaskcreationcheck) | [Styling](styling_checks.markdown#styling-checks) | Checks that a task is declared on a separate line before the closure. |
 GradleTestDependencyVersionCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Checks the version for dependencies in gradle build files. |
-GradleUpgradeReleaseDxpCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | Remove and replaced dependencies in `build.gradle` that are already in `release.dxp.api` with `released.dxp.api` dependency. |
+[GradleUpgradeReleaseDxpCheck](check/gradle_upgrade_release_dxp_check.markdown#gradleupgradereleasedxpcheck) | [Upgrade](upgrade_checks.markdown#upgrade-checks) | Remove and replaced dependencies in `build.gradle` that are already in `release.dxp.api` with `released.dxp.api` dependency. |
 WhitespaceCheck | [Styling](styling_checks.markdown#styling-checks) | Finds missing and unnecessary whitespace. |

--- a/modules/util/source-formatter/src/main/resources/documentation/upgrade_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/upgrade_checks.markdown
@@ -2,6 +2,7 @@
 
 Check | File Extensions | Description
 ----- | --------------- | -----------
+GradleUpgradeReleaseDXPCheck | .gradle | Remove and replaced dependencies in `build.gradle` that are already in `release.dxp.api` with `released.dxp.api` dependency. |
 JSPUpgradeRemovedTagsCheck | .jsp, .jspf, .jspx, .tag, .tpl or .vm | Finds removed tags when upgrading. |
 UpgradeDeprecatedAPICheck | .java | Finds calls to deprecated classes, constructors, fields or methods after an upgrade |
 UpgradeJavaCheck | .java | Performs upgrade checks for `java` files |

--- a/modules/util/source-formatter/src/main/resources/documentation/upgrade_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/upgrade_checks.markdown
@@ -2,7 +2,7 @@
 
 Check | File Extensions | Description
 ----- | --------------- | -----------
-GradleUpgradeReleaseDXPCheck | .gradle | Remove and replaced dependencies in `build.gradle` that are already in `release.dxp.api` with `released.dxp.api` dependency. |
+GradleUpgradeReleaseDxpCheck | .gradle | Remove and replaced dependencies in `build.gradle` that are already in `release.dxp.api` with `released.dxp.api` dependency. |
 JSPUpgradeRemovedTagsCheck | .jsp, .jspf, .jspx, .tag, .tpl or .vm | Finds removed tags when upgrading. |
 UpgradeDeprecatedAPICheck | .java | Finds calls to deprecated classes, constructors, fields or methods after an upgrade |
 UpgradeJavaCheck | .java | Performs upgrade checks for `java` files |

--- a/modules/util/source-formatter/src/main/resources/documentation/upgrade_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/upgrade_checks.markdown
@@ -2,7 +2,7 @@
 
 Check | File Extensions | Description
 ----- | --------------- | -----------
-GradleUpgradeReleaseDxpCheck | .gradle | Remove and replaced dependencies in `build.gradle` that are already in `release.dxp.api` with `released.dxp.api` dependency. |
+[GradleUpgradeReleaseDxpCheck](check/gradle_upgrade_release_dxp_check.markdown#gradleupgradereleasedxpcheck) | .gradle | Remove and replaced dependencies in `build.gradle` that are already in `release.dxp.api` with `released.dxp.api` dependency. |
 JSPUpgradeRemovedTagsCheck | .jsp, .jspf, .jspx, .tag, .tpl or .vm | Finds removed tags when upgrading. |
 UpgradeDeprecatedAPICheck | .java | Finds calls to deprecated classes, constructors, fields or methods after an upgrade |
 UpgradeJavaCheck | .java | Performs upgrade checks for `java` files |

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -315,7 +315,7 @@
 			<property name="allowedDependencyNames" value="com.liferay.arquillian.extension.junit.bridge" />
 			<property name="allowedDependencyNames" value="com.liferay.portal.cache.test.util" />
 		</check>
-		<check name="GradleUpgradeReleaseDXPCheck">
+		<check name="GradleUpgradeReleaseDxpCheck">
 			<category name="Upgrade" />
 			<description name="Remove and replaced dependencies in `build.gradle` that are already in `release.dxp.api` with `released.dxp.api` dependency." />
 		</check>

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -315,6 +315,10 @@
 			<property name="allowedDependencyNames" value="com.liferay.arquillian.extension.junit.bridge" />
 			<property name="allowedDependencyNames" value="com.liferay.portal.cache.test.util" />
 		</check>
+		<check name="GradleUpgradeReleaseDXPCheck">
+			<category name="Upgrade" />
+			<description name="Remove and replaced dependencies in `build.gradle` that are already in `release.dxp.api` with `released.dxp.api` dependency." />
+		</check>
 		<check name="WhitespaceCheck">
 			<category name="Styling" />
 			<description name="Finds missing and unnecessary whitespace." />

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/UpgradeSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/UpgradeSourceProcessorTest.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.processor;
+
+import com.liferay.source.formatter.SourceFormatterArgs;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * @author Kevin Lee
+ */
+public class UpgradeSourceProcessorTest extends BaseSourceProcessorTestCase {
+
+	@Test
+	public void testGradleUpgradeReleaseDxpCheck() throws Exception {
+		test("GradleUpgradeReleaseDxpCheck.testgradle");
+	}
+
+	@Override
+	protected SourceFormatterArgs getSourceFormatterArgs() {
+		List<String> checkCategoryNames = new ArrayList<>();
+
+		checkCategoryNames.add("Upgrade");
+
+		List<String> sourceFormatterProperties = new ArrayList<>();
+
+		sourceFormatterProperties.add(
+			"upgrade.to.version=" + _UPGRADE_TO_VERSION);
+
+		SourceFormatterArgs sourceFormatterArgs =
+			super.getSourceFormatterArgs();
+
+		sourceFormatterArgs.setCheckCategoryNames(checkCategoryNames);
+		sourceFormatterArgs.setSourceFormatterProperties(
+			sourceFormatterProperties);
+
+		return sourceFormatterArgs;
+	}
+
+	private static final String _UPGRADE_TO_VERSION = "7.4.13.u27";
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/GradleUpgradeReleaseDxpCheck.testgradle
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/GradleUpgradeReleaseDxpCheck.testgradle
@@ -1,0 +1,17 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "3.0.0"
+	compileOnly group: "com.liferay.portal", name: "release.dxp.api", version: "7.4.13.u27"
+	compileOnly group: "org.osgi", name: "org.osgi.core", version: "6.0.0"
+
+	testCompile group: "com.liferay.portal", name: "release.dxp.api", version: "7.4.13.u27"
+	testCompile group: "junit", name: "junit", version: "4.12"
+	testCompile group: "org.mockito", name: "mockito-all", version: "1.10.19"
+	testCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "3.6.2"
+	testCompile group: "com.liferay", name: "com.liferay.journal.api", version: "3.0.2"
+	testCompile group: "com.liferay", name: "com.liferay.dynamic.data.mapping.api", version: "4.8.3"
+	testCompile group: "com.liferay", name: "com.liferay.petra.lang", version: "3.0.0"
+}
+
+buildService {
+	apiDir = "../sample-api/src/main/java"
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/GradleUpgradeReleaseDxpCheck.testgradle
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/GradleUpgradeReleaseDxpCheck.testgradle
@@ -1,0 +1,12 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "release.dxp.api", version: "7.4.13.u27"
+	compileOnly group: "org.osgi", name: "org.osgi.core", version: "6.0.0"
+
+	testCompile group: "com.liferay.portal", name: "release.dxp.api", version: "7.4.13.u27"
+	testCompile group: "junit", name: "junit", version: "4.12"
+	testCompile group: "org.mockito", name: "mockito-all", version: "1.10.19"
+}
+
+buildService {
+	apiDir = "../sample-api/src/main/java"
+}

--- a/portal-impl/src/com/liferay/portal/verify/VerifyUUID.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyUUID.java
@@ -15,7 +15,6 @@
 package com.liferay.portal.verify;
 
 import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.bean.PortalBeanLocatorUtil;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
@@ -26,9 +25,6 @@ import com.liferay.portal.kernel.verify.model.VerifiableUUIDModel;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-
-import java.util.Collection;
-import java.util.Map;
 
 /**
  * @author Brian Wing Shun Chan


### PR DESCRIPTION
__Ticket:__
<https://issues.liferay.com/browse/LPS-153072>

__Notes:__
This is a code upgrade SF check for removing `build.gradle` dependencies that are already contained in the release DXP fat JAR and replaces them with `release.dxp.api`. At a high level, the check works in the following way:

1. Fetch and read `release.dxp.api` BOM corresponding to specified target upgrade version (e.g. `7.4.13.u27`).
2. Parse `build.gradle` to identify and locate Gradle dependencies.
3. Remove each Gradle dependency that is already contained in the BOM.
4. Add `release.dxp.api` dependencies if necessary.

The SF check uses a Groovy parser (`org.codehaus.groovy`) so that manipulating the build.gradle is as clean as possible. This parser can be used in the future for other Gradle-based SF checks. I also set up unit tests for future code upgrade SF checks.

Let me know if you have any questions/concerns.