### PR TITLE
[SF] LPS-182585 Create a SF Rule to avoid using more than one service in a component

### DIFF
--- a/modules/apps/roles/roles-test/src/testIntegration/java/com/liferay/roles/service/test/RoleLocalServiceTest.java
+++ b/modules/apps/roles/roles-test/src/testIntegration/java/com/liferay/roles/service/test/RoleLocalServiceTest.java
@@ -342,12 +342,12 @@ public class RoleLocalServiceTest {
 		Assert.assertEquals(
 			1,
 			_roleLocalService.getGroupRolesAndTeamRolesCount(
-				companyId, keyword, excludedRoleNames, keyword, null,
-				roleTypes, 0, groupId));
+				companyId, keyword, excludedRoleNames, keyword, null, roleTypes,
+				0, groupId));
 
 		List<Role> roles = _roleLocalService.getGroupRolesAndTeamRoles(
-			companyId, keyword, excludedRoleNames, keyword, null,
-			roleTypes, 0, groupId, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+			companyId, keyword, excludedRoleNames, keyword, null, roleTypes, 0,
+			groupId, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		Assert.assertEquals(role1, roles.get(0));
 
@@ -356,24 +356,24 @@ public class RoleLocalServiceTest {
 		Assert.assertEquals(
 			0,
 			_roleLocalService.getGroupRolesAndTeamRolesCount(
-				companyId, keyword, excludedRoleNames, keyword, null,
-				roleTypes, 0, groupId));
+				companyId, keyword, excludedRoleNames, keyword, null, roleTypes,
+				0, groupId));
 
 		roles = _roleLocalService.getGroupRolesAndTeamRoles(
-			companyId, keyword, excludedRoleNames, keyword, null,
-			roleTypes, 0, groupId, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+			companyId, keyword, excludedRoleNames, keyword, null, roleTypes, 0,
+			groupId, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		Assert.assertTrue(roles.toString(), roles.isEmpty());
 
 		Assert.assertEquals(
 			1,
 			_roleLocalService.getGroupRolesAndTeamRolesCount(
-				companyId, keyword, excludedRoleNames, keyword,
-				keyword, roleTypes, 0, groupId));
+				companyId, keyword, excludedRoleNames, keyword, keyword,
+				roleTypes, 0, groupId));
 
 		roles = _roleLocalService.getGroupRolesAndTeamRoles(
-			companyId, keyword, excludedRoleNames, keyword, keyword,
-			roleTypes, 0, groupId, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+			companyId, keyword, excludedRoleNames, keyword, keyword, roleTypes,
+			0, groupId, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		Assert.assertEquals(role2, roles.get(0));
 
@@ -389,12 +389,12 @@ public class RoleLocalServiceTest {
 		Assert.assertEquals(
 			1,
 			_roleLocalService.getGroupRolesAndTeamRolesCount(
-				companyId, keyword, excludedRoleNames, keyword, null,
-				roleTypes, 0, groupId));
+				companyId, keyword, excludedRoleNames, keyword, null, roleTypes,
+				0, groupId));
 
 		roles = _roleLocalService.getGroupRolesAndTeamRoles(
-			companyId, keyword, excludedRoleNames, keyword, null,
-			roleTypes, 0, groupId, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+			companyId, keyword, excludedRoleNames, keyword, null, roleTypes, 0,
+			groupId, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		_role = roles.get(0);
 
@@ -403,12 +403,12 @@ public class RoleLocalServiceTest {
 		Assert.assertEquals(
 			2,
 			_roleLocalService.getGroupRolesAndTeamRolesCount(
-				companyId, keyword, excludedRoleNames, keyword,
-				keyword, roleTypes, 0, groupId));
+				companyId, keyword, excludedRoleNames, keyword, keyword,
+				roleTypes, 0, groupId));
 
 		roles = _roleLocalService.getGroupRolesAndTeamRoles(
-			companyId, keyword, excludedRoleNames, keyword, keyword,
-			roleTypes, 0, groupId, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+			companyId, keyword, excludedRoleNames, keyword, keyword, roleTypes,
+			0, groupId, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		_role = roles.get(0);
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaComponentAnnotationsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaComponentAnnotationsCheck.java
@@ -490,10 +490,8 @@ public class JavaComponentAnnotationsCheck extends JavaAnnotationsCheck {
 			_CHECK_MISMATCHED_SERVICE_ATTRIBUTE_KEY, absolutePath);
 		boolean checkSelfRegistration = isAttributeValue(
 			_CHECK_SELF_REGISTRATION_KEY, absolutePath);
-
-		if (!checkMismatchedServiceAttribute && !checkSelfRegistration) {
-			return annotation;
-		}
+		boolean checkHasMultipleServiceTypes = isAttributeValue(
+			_CHECK_HAS_MULTIPLE_SERVICE_TYPES_KEY, absolutePath);
 
 		if (checkMismatchedServiceAttribute &&
 			!serviceAttributeValue.equals(expectedServiceAttributeValue)) {
@@ -508,6 +506,28 @@ public class JavaComponentAnnotationsCheck extends JavaAnnotationsCheck {
 				fileName,
 				"No need to register '" + className +
 					"' in @Component 'service' attribute");
+		}
+
+		if (checkHasMultipleServiceTypes) {
+			List<String> allowedMultipleServicesClassNames = getAttributeValues(
+				_ALLOWED_MULTIPLE_SERVICE_TYPES_CLASS_NAMES_KEY, absolutePath);
+
+			for (String allowedMultipleServicesClassName :
+					allowedMultipleServicesClassNames) {
+
+				if (absolutePath.contains(allowedMultipleServicesClassName)) {
+					return annotation;
+				}
+			}
+
+			if (StringUtil.startsWith(serviceAttributeValue, '{') &&
+				serviceAttributeValue.contains(",")) {
+
+				addMessage(
+					fileName,
+					"@Component classes should only specify one service type " +
+						"in the 'service' attribute, see LPS-180838");
+			}
 		}
 
 		return annotation;
@@ -586,11 +606,18 @@ public class JavaComponentAnnotationsCheck extends JavaAnnotationsCheck {
 	private static final String _ALLOWED_IMMEDIATE_ATTRIBUTE_CLASS_NAMES_KEY =
 		"allowedImmediateAttributeClassNames";
 
+	private static final String
+		_ALLOWED_MULTIPLE_SERVICE_TYPES_CLASS_NAMES_KEY =
+			"allowedMultipleServiceTypesClassNames";
+
 	private static final String _CHECK_CONFIGURATION_PID_ATTRIBUTE_KEY =
 		"checkConfigurationPidAttribute";
 
 	private static final String _CHECK_CONFIGURATION_POLICY_ATTRIBUTE_KEY =
 		"checkConfigurationPolicyAttribute";
+
+	private static final String _CHECK_HAS_MULTIPLE_SERVICE_TYPES_KEY =
+		"checkHasMultipleServiceTypes";
 
 	private static final String _CHECK_IMMEDIATE_ATTRIBUTE_KEY =
 		"checkImmediateAttribute";

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaComponentAnnotationsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaComponentAnnotationsCheck.java
@@ -20,7 +20,9 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.NaturalOrderStringComparator;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.tools.GitUtil;
 import com.liferay.portal.tools.ToolsUtil;
+import com.liferay.source.formatter.SourceFormatterArgs;
 import com.liferay.source.formatter.check.util.BNDSourceUtil;
 import com.liferay.source.formatter.check.util.JavaSourceUtil;
 import com.liferay.source.formatter.check.util.SourceUtil;
@@ -29,6 +31,7 @@ import com.liferay.source.formatter.parser.JavaMethod;
 import com.liferay.source.formatter.parser.JavaParameter;
 import com.liferay.source.formatter.parser.JavaSignature;
 import com.liferay.source.formatter.parser.JavaTerm;
+import com.liferay.source.formatter.processor.SourceProcessor;
 
 import java.io.File;
 
@@ -50,8 +53,9 @@ public class JavaComponentAnnotationsCheck extends JavaAnnotationsCheck {
 
 	@Override
 	protected String formatAnnotation(
-		String fileName, String absolutePath, JavaClass javaClass,
-		String fileContent, String annotation, String indent) {
+			String fileName, String absolutePath, JavaClass javaClass,
+			String fileContent, String annotation, String indent)
+		throws Exception {
 
 		String trimmedAnnotation = StringUtil.trim(annotation);
 
@@ -143,6 +147,64 @@ public class JavaComponentAnnotationsCheck extends JavaAnnotationsCheck {
 		}
 
 		return newProperties + properties;
+	}
+
+	private void _checkHasMultipleServiceTypes(
+			String fileName, String absolutePath)
+		throws Exception {
+
+		SourceProcessor sourceProcessor = getSourceProcessor();
+
+		SourceFormatterArgs sourceFormatterArgs =
+			sourceProcessor.getSourceFormatterArgs();
+
+		if (!sourceFormatterArgs.isFormatCurrentBranch()) {
+			return;
+		}
+
+		List<String> allowedMultipleServicesClassNames = getAttributeValues(
+			_ALLOWED_MULTIPLE_SERVICE_TYPES_CLASS_NAMES_KEY, absolutePath);
+
+		for (String allowedMultipleServicesClassName :
+				allowedMultipleServicesClassNames) {
+
+			if (absolutePath.contains(allowedMultipleServicesClassName)) {
+				return;
+			}
+		}
+
+		String currentBranchFileDiff = GitUtil.getCurrentBranchFileDiff(
+			sourceFormatterArgs.getBaseDirName(),
+			sourceFormatterArgs.getGitWorkingBranchName(), absolutePath);
+
+		for (String currentBranchFileDiffBlock :
+				StringUtil.split(currentBranchFileDiff, "\n@@")) {
+
+			if (currentBranchFileDiffBlock.startsWith("diff") ||
+				!currentBranchFileDiffBlock.contains("@Component")) {
+
+				continue;
+			}
+
+			for (String line :
+					StringUtil.splitLines(currentBranchFileDiffBlock)) {
+
+				if (!line.startsWith(StringPool.PLUS)) {
+					continue;
+				}
+
+				if (line.contains("service = {") &&
+					!line.contains("service = {}")) {
+
+					addMessage(
+						fileName,
+						"@Component classes should only specify one service " +
+							"type in the 'service' attribute, see LPS-180838");
+
+					break;
+				}
+			}
+		}
 	}
 
 	private void _checkImmediateAttribute(
@@ -472,8 +534,9 @@ public class JavaComponentAnnotationsCheck extends JavaAnnotationsCheck {
 	}
 
 	private String _formatServiceAttribute(
-		String fileName, String absolutePath, String className,
-		String annotation, List<String> implementedClassNames) {
+			String fileName, String absolutePath, String className,
+			String annotation, List<String> implementedClassNames)
+		throws Exception {
 
 		String expectedServiceAttributeValue =
 			_getExpectedServiceAttributeValue(implementedClassNames);
@@ -509,25 +572,7 @@ public class JavaComponentAnnotationsCheck extends JavaAnnotationsCheck {
 		}
 
 		if (checkHasMultipleServiceTypes) {
-			List<String> allowedMultipleServicesClassNames = getAttributeValues(
-				_ALLOWED_MULTIPLE_SERVICE_TYPES_CLASS_NAMES_KEY, absolutePath);
-
-			for (String allowedMultipleServicesClassName :
-					allowedMultipleServicesClassNames) {
-
-				if (absolutePath.contains(allowedMultipleServicesClassName)) {
-					return annotation;
-				}
-			}
-
-			if (StringUtil.startsWith(serviceAttributeValue, '{') &&
-				serviceAttributeValue.contains(",")) {
-
-				addMessage(
-					fileName,
-					"@Component classes should only specify one service type " +
-						"in the 'service' attribute, see LPS-180838");
-			}
+			_checkHasMultipleServiceTypes(fileName, absolutePath);
 		}
 
 		return annotation;

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -660,6 +660,7 @@
 			<description name="Performs several checks on classes with `@Component` annotation." />
 			<property name="checkConfigurationPidAttribute" value="true" />
 			<property name="checkConfigurationPolicyAttribute" value="false" />
+			<property name="checkHasMultipleServiceTypes" value="false" />
 			<property name="checkMismatchedServiceAttribute" value="false" />
 			<property name="checkSelfRegistration" value="false" />
 		</check>

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -589,6 +589,8 @@
         modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist-impl/src/main/java/com/liferay/portal/bundle/blacklist/internal/BundleBlacklistManagerImpl.java,\
         modules/apps/static/portal-component-blacklist/portal-component-blacklist-impl/src/main/java/com/liferay/portal/component/blacklist/internal/ComponentBlacklistImpl.java
 
+    source.check.JavaComponentAnnotationsCheck.allowedMultipleServiceTypesClassNames=
+
     source.check.JavaComponentAnnotationsCheck.checkImmediateAttribute=true
 
     source.check.JavaComponentAnnotationsCheck.checkPortletVersion=true

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -593,6 +593,8 @@
 
     source.check.JavaComponentAnnotationsCheck.checkImmediateAttribute=true
 
+    source.check.JavaComponentAnnotationsCheck.checkHasMultipleServiceTypes=true
+
     source.check.JavaComponentAnnotationsCheck.checkPortletVersion=true
 
     source.check.JavaComponentAnnotationsCheck.enterpriseAppModulePathNames=\


### PR DESCRIPTION
__Ticket:__ <https://issues.liferay.com/browse/LPS-182585>

This pull request expands `JavaComponentAnnotationsCheck` to check for `@Component` classes with multiple service classes defined in the `service` attribute. For now, it will only for check for incoming changes in `master`. In the future, commit 2c8751e9feb1ef737cb4f70461068fd1502e89e5 will need to be reverted.