### PR TITLE
LPS-185518 Create a SF check for replace with searchContainer.setResultsAndTotal

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaSetResultsSetTotalMethodCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaSetResultsSetTotalMethodCheck.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.check;
+
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.source.formatter.check.util.JavaSourceUtil;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Tamyris Bernardo
+ */
+public class UpgradeJavaSetResultsSetTotalMethodCheck extends BaseFileCheck {
+
+	@Override
+	protected String doProcess(
+			String fileName, String absolutePath, String content)
+		throws Exception {
+
+		if (!fileName.endsWith(".java") && !fileName.endsWith(".jsp") &&
+			!fileName.endsWith(".jspf")) {
+
+			return content;
+		}
+
+		content = _removeSetTotal(content);
+		content = _replaceSetResults(content);
+
+		return content;
+	}
+
+	private boolean _hasClassName(
+		String className, String content, String methodCall) {
+
+		String variable = methodCall.substring(
+			0, methodCall.indexOf(CharPool.PERIOD));
+
+		String variableTypeName = getVariableTypeName(
+			content, content, variable, true);
+
+		if (variableTypeName.contains(className)) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private String _removeSetTotal(String content) {
+		String newContent = content;
+		Matcher setTotalMatcher = _setTotalPattern.matcher(content);
+
+		while (setTotalMatcher.find()) {
+			String methodCall = JavaSourceUtil.getMethodCall(
+				content, setTotalMatcher.start());
+
+			String fullMethodCall = StringBundler.concat(
+				StringPool.NEW_LINE, methodCall, StringPool.SEMICOLON,
+				StringPool.NEW_LINE);
+
+			if (_hasClassName("SearchContainer", content, methodCall.trim())) {
+				newContent = StringUtil.removeSubstring(
+					newContent, fullMethodCall);
+			}
+		}
+
+		return newContent;
+	}
+
+	private String _replaceSetResults(String content) {
+		String newContent = content;
+		Matcher setResultsMatcher = _setResultsPattern.matcher(content);
+
+		while (setResultsMatcher.find()) {
+			String methodCall = JavaSourceUtil.getMethodCall(
+				content, setResultsMatcher.start());
+
+			if (_hasClassName("SearchContainer", content, methodCall.trim())) {
+				newContent = StringUtil.replace(
+					newContent, methodCall,
+					StringUtil.replace(
+						methodCall, ".setResults(", ".setResultsAndTotal("));
+			}
+		}
+
+		return newContent;
+	}
+
+	private static final Pattern _setResultsPattern = Pattern.compile(
+		"\\w+\\.setResults\\(");
+	private static final Pattern _setTotalPattern = Pattern.compile(
+		"\\t*?\\w+\\.setTotal\\(");
+
+}

--- a/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
@@ -453,6 +453,7 @@ UpgradeJavaAddFolderParameterCheck | [Upgrade](upgrade_checks.markdown#upgrade-c
 UpgradeJavaCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | .bnd, .gradle, .java or .vm | Performs upgrade checks for `java` files |
 UpgradeJavaExtractTextMethodCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | .bnd, .gradle, .java or .vm | Replaces the references of the method `HtmlUtil.extractText(` with the method `extractText(` of `HtmlParser` class |
 UpgradeJavaServiceReferenceAnnotationCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | .bnd, .gradle, .java or .vm | Run code migration to replace '@ServiceReference' by '@Reference' |
+UpgradeJavaSetResultsSetTotalMethodCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | .bnd, .gradle, .java or .vm | Run code migration of method searchContainer.setResults to the searchContainer.setResultsAndTotal and delete searchContainer.setTotal |
 [UpgradeProcessCheck](check/upgrade_process_check.markdown#upgradeprocesscheck) | [Performance](performance_checks.markdown#performance-checks) | .java | Performs several checks on `*UpgradeProcess` classes. |
 UpgradeRemovedAPICheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | .java | Finds cases where calls are made to removed API after an upgrade. |
 UpgradeVelocityCommentMigrationCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | .bnd, .gradle, .java or .vm | Run code migration of comments from a Velocity file to a Freemarker file with the syntax replacements |

--- a/modules/util/source-formatter/src/main/resources/documentation/upgrade_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/upgrade_checks.markdown
@@ -14,6 +14,7 @@ UpgradeJavaAddFolderParameterCheck | .bnd, .gradle, .java or .vm | Fill the new 
 UpgradeJavaCheck | .bnd, .gradle, .java or .vm | Performs upgrade checks for `java` files |
 UpgradeJavaExtractTextMethodCheck | .bnd, .gradle, .java or .vm | Replaces the references of the method `HtmlUtil.extractText(` with the method `extractText(` of `HtmlParser` class |
 UpgradeJavaServiceReferenceAnnotationCheck | .bnd, .gradle, .java or .vm | Run code migration to replace '@ServiceReference' by '@Reference' |
+UpgradeJavaSetResultsSetTotalMethodCheck | .bnd, .gradle, .java or .vm | Run code migration of method searchContainer.setResults to the searchContainer.setResultsAndTotal and delete searchContainer.setTotal |
 UpgradeRemovedAPICheck | .java | Finds cases where calls are made to removed API after an upgrade. |
 UpgradeVelocityCommentMigrationCheck | .bnd, .gradle, .java or .vm | Run code migration of comments from a Velocity file to a Freemarker file with the syntax replacements |
 UpgradeVelocityFileImportMigrationCheck | .bnd, .gradle, .java or .vm | Run code migration of file import from a Velocity file to a Freemarker file with the syntax replacements |

--- a/modules/util/source-formatter/src/main/resources/documentation/upgrade_source_processor_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/upgrade_source_processor_checks.markdown
@@ -8,6 +8,7 @@ UpgradeJavaAddFolderParameterCheck | [Upgrade](upgrade_checks.markdown#upgrade-c
 UpgradeJavaCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | Performs upgrade checks for `java` files |
 UpgradeJavaExtractTextMethodCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | Replaces the references of the method `HtmlUtil.extractText(` with the method `extractText(` of `HtmlParser` class |
 UpgradeJavaServiceReferenceAnnotationCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | Run code migration to replace '@ServiceReference' by '@Reference' |
+UpgradeJavaSetResultsSetTotalMethodCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | Run code migration of method searchContainer.setResults to the searchContainer.setResultsAndTotal and delete searchContainer.setTotal |
 UpgradeVelocityCommentMigrationCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | Run code migration of comments from a Velocity file to a Freemarker file with the syntax replacements |
 UpgradeVelocityFileImportMigrationCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | Run code migration of file import from a Velocity file to a Freemarker file with the syntax replacements |
 UpgradeVelocityForeachMigrationCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | Run code migration of references to Foreach statement from a Velocity file to a Freemarker file with the syntax replacements |

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -1596,6 +1596,10 @@
 			<category name="Upgrade" />
 			<description name="Run code migration to replace '@ServiceReference' by '@Reference'" />
 		</check>
+		<check name="UpgradeJavaSetResultsSetTotalMethodCheck">
+			<category name="Upgrade" />
+			<description name="Run code migration of method searchContainer.setResults to the searchContainer.setResultsAndTotal and delete searchContainer.setTotal" />
+		</check>
 		<check name="UpgradeVelocityCommentMigrationCheck">
 			<category name="Upgrade" />
 			<description name="Run code migration of comments from a Velocity file to a Freemarker file with the syntax replacements" />

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/UpgradeSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/UpgradeSourceProcessorTest.java
@@ -81,6 +81,13 @@ public class UpgradeSourceProcessorTest extends BaseSourceProcessorTestCase {
 	}
 
 	@Test
+	public void testUpgradeJavaSetResultsSetTotalMethodCheck()
+		throws Exception {
+
+		test("upgrade/UpgradeJavaSetResultsSetTotalMethodCheck.testjava");
+	}
+
+	@Test
 	public void testUpgradeVelocityMigrationCheck() throws Exception {
 		test(
 			SourceProcessorTestParameters.create(

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeJavaSetResultsSetTotalMethodCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeJavaSetResultsSetTotalMethodCheck.testjava
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Tamyris Bernardo
+ */
+public class UpgradeJavaSetResultsSetTotalMethodCheck {
+
+	public void method() {
+		SearchContainer<AnnouncementsEntry>
+			announcementsEntriesSearchContainer = new SearchContainer();
+
+		announcementsEntriesSearchContainer.setResultsAndTotal(consumers);
+
+		SearchContainer vocabulariesSearchContainer = new SearchContainer();
+
+		vocabulariesSearchContainer.setResultsAndTotal(consumers);
+	}
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeJavaSetResultsSetTotalMethodCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeJavaSetResultsSetTotalMethodCheck.testjava
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Tamyris Bernardo
+ */
+public class UpgradeJavaSetResultsSetTotalMethodCheck {
+
+	public void method() {
+		SearchContainer<AnnouncementsEntry>
+			announcementsEntriesSearchContainer = new SearchContainer();
+
+		announcementsEntriesSearchContainer.setTotal(
+			Long.valueOf(
+				ConsumerLocalServiceUtil.countConsumerByCriterias(
+					this.keywords, this.status)
+			).intValue());
+
+		announcementsEntriesSearchContainer.setResults(consumers);
+
+		SearchContainer vocabulariesSearchContainer = new SearchContainer();
+
+		vocabulariesSearchContainer.setTotal(
+			Long.valueOf(
+				ConsumerLocalServiceUtil.countConsumerByCriterias(
+					this.keywords, this.status)
+			).intValue());
+
+		vocabulariesSearchContainer.setResults(consumers);
+	}
+
+}


### PR DESCRIPTION
 Ticket: https://issues.liferay.com/browse/LPS-185518
 
 Hello Kevin.
This check asks to replace the 'setResults' method with 'setResultsAndTotal'. Also, remove the 'setTotal' method.

You already reviewed this code, and you asked me about '_hasClassName("SearchContainer", ' if it was necessary to have the name of the class. So, it's necessary because there are other '.setResults' and 'setTotal' methods in other classes, that aren't SearchContainer. That's why, I put this validation. 

Can you review this pull request, please?