### PR TITLE
LPS-186817 Method getItems(httpServletRequest, filter, pagination, sort) had the order of the parameters changed

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaFDSDataProviderCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaFDSDataProviderCheck.java
@@ -1,0 +1,238 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.check;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.source.formatter.check.util.JavaSourceUtil;
+import com.liferay.source.formatter.parser.JavaClass;
+import com.liferay.source.formatter.parser.JavaClassParser;
+import com.liferay.source.formatter.parser.JavaMethod;
+import com.liferay.source.formatter.parser.JavaTerm;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Michael Cavalcanti
+ */
+public class UpgradeJavaFDSDataProviderCheck extends BaseFileCheck {
+
+	@Override
+	protected String doProcess(
+			String fileName, String absolutePath, String content)
+		throws Exception {
+
+		if (!fileName.endsWith(".java")) {
+			return content;
+		}
+
+		JavaClass javaClass = JavaClassParser.parseJavaClass(fileName, content);
+
+		List<String> importNames = javaClass.getImportNames();
+
+		if (!importNames.contains(
+				"com.liferay.frontend.data.set.provider.FDSDataProvider")) {
+
+			return content;
+		}
+
+		return _reorderParametersGetItemsAndGetItemsCount(content, javaClass);
+	}
+
+	private String _checkMethodCalls(String content, String javaMethodContent) {
+		Matcher methodCallGetItemsMatcher = _methodCallGetItemsPattern.matcher(
+			javaMethodContent);
+
+		while (methodCallGetItemsMatcher.find()) {
+			String methodCall = JavaSourceUtil.getMethodCall(
+				javaMethodContent, methodCallGetItemsMatcher.start());
+
+			List<String> parameterList = JavaSourceUtil.getParameterList(
+				methodCall);
+
+			if (_hasClassNameHttpServletRequest(
+					javaMethodContent, content, parameterList.get(0)) &&
+				_isFDSDataProviderMethodCall(
+					javaMethodContent, content, methodCall)) {
+
+				javaMethodContent = StringUtil.replace(
+					javaMethodContent, methodCall,
+					_reorderParametersGetItems(
+						methodCall, methodCallGetItemsMatcher.group(1),
+						parameterList));
+			}
+		}
+
+		Matcher methodCallGetItemsCountMatcher =
+			_methodCallGetItemsCountPattern.matcher(javaMethodContent);
+
+		while (methodCallGetItemsCountMatcher.find()) {
+			String methodCall = JavaSourceUtil.getMethodCall(
+				javaMethodContent, methodCallGetItemsCountMatcher.start());
+
+			List<String> parameterList = JavaSourceUtil.getParameterList(
+				methodCall);
+
+			if (_hasClassNameHttpServletRequest(
+					javaMethodContent, content, parameterList.get(0)) &&
+				_isFDSDataProviderMethodCall(
+					javaMethodContent, content, methodCall)) {
+
+				javaMethodContent = StringUtil.replace(
+					javaMethodContent, methodCall,
+					_reorderParametersGetItemsCount(
+						methodCall, methodCallGetItemsCountMatcher.group(1),
+						parameterList));
+			}
+		}
+
+		return javaMethodContent;
+	}
+
+	private String _checkMethods(String javaMethodContent) {
+		Matcher methodGetItemsMatcher = _methodGetItemsPattern.matcher(
+			javaMethodContent);
+
+		if (methodGetItemsMatcher.find()) {
+			String methodCall = JavaSourceUtil.getMethodCall(
+				javaMethodContent, methodGetItemsMatcher.start());
+
+			List<String> parameterList = JavaSourceUtil.getParameterList(
+				methodCall);
+
+			String firstParameter = parameterList.get(0);
+
+			if (firstParameter.contains("HttpServletRequest")) {
+				javaMethodContent = StringUtil.replace(
+					javaMethodContent, methodCall,
+					_reorderParametersGetItems(
+						methodCall, methodGetItemsMatcher.group(1),
+						parameterList));
+			}
+		}
+
+		Matcher methodGetItemsCountMatcher =
+			_methodGetItemsCountPattern.matcher(javaMethodContent);
+
+		if (methodGetItemsCountMatcher.find()) {
+			String methodCall = JavaSourceUtil.getMethodCall(
+				javaMethodContent, methodGetItemsCountMatcher.start());
+
+			List<String> parameterList = JavaSourceUtil.getParameterList(
+				methodCall);
+
+			String firstParameter = parameterList.get(0);
+
+			if (firstParameter.contains("HttpServletRequest")) {
+				javaMethodContent = StringUtil.replace(
+					javaMethodContent, methodCall,
+					_reorderParametersGetItemsCount(
+						methodCall, methodGetItemsCountMatcher.group(1),
+						parameterList));
+			}
+		}
+
+		return javaMethodContent;
+	}
+
+	private boolean _hasClassNameHttpServletRequest(
+		String content, String fileContent, String variableName) {
+
+		return Objects.equals(
+			getVariableTypeName(content, fileContent, variableName),
+			"HttpServletRequest");
+	}
+
+	private boolean _isFDSDataProviderMethodCall(
+		String content, String fileContent, String methodCall) {
+
+		String variableTypeName = getVariableTypeName(
+			content, fileContent,
+			methodCall.substring(0, methodCall.indexOf(StringPool.PERIOD)),
+			true);
+
+		return variableTypeName.contains("FDSDataProvider");
+	}
+
+	private String _reorderParametersGetItems(
+		String methodCall, String orderParameters, List<String> parameterList) {
+
+		String newOrderParameters = StringBundler.concat(
+			parameterList.get(1), StringPool.COMMA_AND_SPACE,
+			parameterList.get(2), StringPool.COMMA_AND_SPACE,
+			parameterList.get(0), StringPool.COMMA_AND_SPACE,
+			parameterList.get(3));
+
+		return StringUtil.replace(
+			methodCall, orderParameters, newOrderParameters);
+	}
+
+	private String _reorderParametersGetItemsAndGetItemsCount(
+		String content, JavaClass javaClass) {
+
+		List<String> implementedClassNames =
+			javaClass.getImplementedClassNames();
+
+		boolean implementsFDSDataProvider = implementedClassNames.contains(
+			"FDSDataProvider");
+
+		for (JavaTerm childJavaTerm : javaClass.getChildJavaTerms()) {
+			if (!childJavaTerm.isJavaMethod()) {
+				continue;
+			}
+
+			JavaMethod javaMethod = (JavaMethod)childJavaTerm;
+
+			String javaMethodContent = javaMethod.getContent();
+
+			if (implementsFDSDataProvider) {
+				content = StringUtil.replace(
+					content, javaMethodContent,
+					_checkMethods(javaMethodContent));
+			}
+
+			content = StringUtil.replace(
+				content, javaMethodContent,
+				_checkMethodCalls(javaClass.getContent(), javaMethodContent));
+		}
+
+		return content;
+	}
+
+	private String _reorderParametersGetItemsCount(
+		String methodCall, String orderParameters, List<String> parameterList) {
+
+		String newOrderParameters = StringBundler.concat(
+			parameterList.get(1), StringPool.COMMA_AND_SPACE,
+			parameterList.get(0));
+
+		return StringUtil.replace(
+			methodCall, orderParameters, newOrderParameters);
+	}
+
+	private static final Pattern _methodCallGetItemsCountPattern =
+		Pattern.compile("\\w+\\.getItemsCount\\((\\s*.+,\\s*.+)\\s*\\)");
+	private static final Pattern _methodCallGetItemsPattern = Pattern.compile(
+		"\\w+\\.getItems\\((\\s*.+,\\s*.+,\\s*.+,\\s*.+)\\s*\\)");
+	private static final Pattern _methodGetItemsCountPattern = Pattern.compile(
+		"getItemsCount\\((\\s*.+,\\s*.+)\\s*\\)");
+	private static final Pattern _methodGetItemsPattern = Pattern.compile(
+		"getItems\\((\\s*.+,\\s*.+,\\s*.+,\\s*.+)\\s*\\)");
+
+}

--- a/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
@@ -453,6 +453,7 @@ UpgradeGradleIncludeResourceCheck | [Upgrade](upgrade_checks.markdown#upgrade-ch
 UpgradeJavaAddFolderParameterCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | .bnd, .gradle, .java or .vm | Fill the new parameter of the method `addFolder` of `JournalFolderService`, `JournalFolderLocalService`, and `JournalFolderLocalServiceUtil` classes |
 UpgradeJavaCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | .bnd, .gradle, .java or .vm | Performs upgrade checks for `java` files |
 UpgradeJavaExtractTextMethodCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | .bnd, .gradle, .java or .vm | Replaces the references of the method `HtmlUtil.extractText(` with the method `extractText(` of `HtmlParser` class |
+UpgradeJavaFDSDataProviderCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | .bnd, .gradle, .java or .vm | Reorder parameters in the getItems and getItemsCount methods of the FDSDataProvider interface |
 UpgradeJavaMultiVMPoolUtilCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | .bnd, .gradle, .java or .vm | Replaces the references of the MultiVMPoolUtil class and also its methods usages. |
 UpgradeJavaServiceReferenceAnnotationCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | .bnd, .gradle, .java or .vm | Run code migration to replace '@ServiceReference' by '@Reference' |
 [UpgradeProcessCheck](check/upgrade_process_check.markdown#upgradeprocesscheck) | [Performance](performance_checks.markdown#performance-checks) | .java | Performs several checks on `*UpgradeProcess` classes. |

--- a/modules/util/source-formatter/src/main/resources/documentation/upgrade_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/upgrade_checks.markdown
@@ -14,6 +14,7 @@ UpgradeGradleIncludeResourceCheck | .bnd, .gradle, .java or .vm | Replaces with 
 UpgradeJavaAddFolderParameterCheck | .bnd, .gradle, .java or .vm | Fill the new parameter of the method `addFolder` of `JournalFolderService`, `JournalFolderLocalService`, and `JournalFolderLocalServiceUtil` classes |
 UpgradeJavaCheck | .bnd, .gradle, .java or .vm | Performs upgrade checks for `java` files |
 UpgradeJavaExtractTextMethodCheck | .bnd, .gradle, .java or .vm | Replaces the references of the method `HtmlUtil.extractText(` with the method `extractText(` of `HtmlParser` class |
+UpgradeJavaFDSDataProviderCheck | .bnd, .gradle, .java or .vm | Reorder parameters in the getItems and getItemsCount methods of the FDSDataProvider interface |
 UpgradeJavaMultiVMPoolUtilCheck | .bnd, .gradle, .java or .vm | Replaces the references of the MultiVMPoolUtil class and also its methods usages. |
 UpgradeJavaServiceReferenceAnnotationCheck | .bnd, .gradle, .java or .vm | Run code migration to replace '@ServiceReference' by '@Reference' |
 UpgradeRemovedAPICheck | .java | Finds cases where calls are made to removed API after an upgrade. |

--- a/modules/util/source-formatter/src/main/resources/documentation/upgrade_source_processor_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/upgrade_source_processor_checks.markdown
@@ -7,6 +7,7 @@ UpgradeGradleIncludeResourceCheck | [Upgrade](upgrade_checks.markdown#upgrade-ch
 UpgradeJavaAddFolderParameterCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | Fill the new parameter of the method `addFolder` of `JournalFolderService`, `JournalFolderLocalService`, and `JournalFolderLocalServiceUtil` classes |
 UpgradeJavaCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | Performs upgrade checks for `java` files |
 UpgradeJavaExtractTextMethodCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | Replaces the references of the method `HtmlUtil.extractText(` with the method `extractText(` of `HtmlParser` class |
+UpgradeJavaFDSDataProviderCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | Reorder parameters in the getItems and getItemsCount methods of the FDSDataProvider interface |
 UpgradeJavaMultiVMPoolUtilCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | Replaces the references of the MultiVMPoolUtil class and also its methods usages. |
 UpgradeJavaServiceReferenceAnnotationCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | Run code migration to replace '@ServiceReference' by '@Reference' |
 UpgradeVelocityCommentMigrationCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | Run code migration of comments from a Velocity file to a Freemarker file with the syntax replacements |

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -1592,10 +1592,16 @@
 		<check name="UpgradeJavaCheck">
 			<category name="Upgrade" />
 			<description name="Performs upgrade checks for `java` files" />
+			<weight>2</weight>
 		</check>
 		<check name="UpgradeJavaExtractTextMethodCheck">
 			<category name="Upgrade" />
 			<description name="Replaces the references of the method `HtmlUtil.extractText(` with the method `extractText(` of `HtmlParser` class" />
+		</check>
+		<check name="UpgradeJavaFDSDataProviderCheck">
+			<category name="Upgrade" />
+			<description name="Reorder parameters in the getItems and getItemsCount methods of the FDSDataProvider interface" />
+			<weight>1</weight>
 		</check>
 		<check name="UpgradeJavaMultiVMPoolUtilCheck">
 			<category name="Upgrade" />

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/UpgradeSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/UpgradeSourceProcessorTest.java
@@ -69,6 +69,11 @@ public class UpgradeSourceProcessorTest extends BaseSourceProcessorTestCase {
 	}
 
 	@Test
+	public void testUpgradeJavaFDSDataProviderCheck() throws Exception {
+		test("upgrade/UpgradeJavaFDSDataProviderCheck.testjava");
+	}
+
+	@Test
 	public void testUpgradeJavaModelPermissionsCheck() throws Exception {
 		test("upgrade/UpgradeJavaModelPermissionsCheck.testjava");
 	}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeJavaFDSDataProviderCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeJavaFDSDataProviderCheck.testjava
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import com.liferay.frontend.data.set.provider.FDSDataProvider;
+
+/**
+ * @author Michael Cavalcanti
+ */
+public class UpgradeJavaFDSDataProviderCheck implements FDSDataProvider {
+
+	@Override
+	public List getItems(FDSKeywords fdsKeywords, FDSPagination pagination, HttpServletRequest httpServletRequest, Sort sort)
+		throws PortalException {
+
+		return _original.getItems(fdsKeywords, pagination, httpServletRequest, sort);
+	}
+
+	@Override
+	public int getItemsCount(FDSKeywords fdsKeywords, HttpServletRequest httpServletRequest)
+		throws PortalException {
+
+		return _original.getItemsCount(fdsKeywords, httpServletRequest);
+	}
+
+	private FDSDataProvider<?> _original;
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeJavaFDSDataProviderCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeJavaFDSDataProviderCheck.testjava
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import com.liferay.frontend.data.set.provider.FDSDataProvider;
+
+/**
+ * @author Michael Cavalcanti
+ */
+public class UpgradeJavaFDSDataProviderCheck implements FDSDataProvider {
+
+	@Override
+	public List getItems(
+			HttpServletRequest httpServletRequest, FDSKeywords fdsKeywords,
+			FDSPagination pagination, Sort sort)
+		throws PortalException {
+
+		return _original.getItems(
+			httpServletRequest, fdsKeywords, pagination, sort);
+	}
+
+	@Override
+	public int getItemsCount(
+			HttpServletRequest httpServletRequest, FDSKeywords fdsKeywords)
+		throws PortalException {
+
+		return _original.getItemsCount(httpServletRequest, fdsKeywords);
+	}
+
+	private FDSDataProvider<?> _original;
+
+}


### PR DESCRIPTION
Hi Kevin,
The purpose of this check is to sort the variables of the getItems and getItemsCount methods and also their method calls.
I had some problems during the implementation that made me take some questionable directions.

1 - I created a regex that checks if the interface was implemented or not, in the client code I saw situations where the interface was imported but not implemented, it was used for a different purpose.
2 - The client uses the interface in a different way than the conventional one, as can be seen in the test file.
3 - The getVariableTypeName method does not work correctly with variables with type that have generics(so i tried a workaround solution), as can be seen in the test file.

I am waiting for your revision and suggestions.