### PR TITLE
LPS-186054 Create a SF rule to Use ModelPermissions instead of serviceContext.setGuestPermissions() and serviceContext.setGroupPermissions()

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaUpgradeModelPermissionsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaUpgradeModelPermissionsCheck.java
@@ -126,48 +126,34 @@ public class JavaUpgradeModelPermissionsCheck extends BaseJavaTermCheck {
 		Matcher setGroupPermissionsMatcher, Matcher setGuestPermissionsMatcher,
 		String javaTermContent) {
 
-		if (hasSetGroupPermissions && hasSetGuestPermissions) {
-			String modelPermissionsImplementation =
-				_getModelPermissionsImplementation(
-					setGroupPermissionsMatcher.group(2),
-					setGuestPermissionsMatcher.group(2),
-					SourceUtil.getIndent(setGroupPermissionsMatcher.group(0)),
-					setGroupPermissionsMatcher.group(1));
+		String oldSub;
+		String serviceContext;
+		String groupPermissions = "new String[0]";
+		String guestPermissions = "new String[0]";
 
-			javaTermContent = StringUtil.replace(
-				javaTermContent,
-				new String[] {
-					setGroupPermissionsMatcher.group(0),
-					setGuestPermissionsMatcher.group(0)
-				},
-				new String[] {
-					modelPermissionsImplementation, StringPool.BLANK
-				});
-		}
-		else if (hasSetGroupPermissions) {
-			String modelPermissionsImplementation =
-				_getModelPermissionsImplementation(
-					setGroupPermissionsMatcher.group(2), "new String[0]",
-					SourceUtil.getIndent(setGroupPermissionsMatcher.group(0)),
-					setGroupPermissionsMatcher.group(1));
+		if (hasSetGroupPermissions) {
+			oldSub = setGroupPermissionsMatcher.group(0);
+			serviceContext = setGroupPermissionsMatcher.group(1);
+			groupPermissions = setGroupPermissionsMatcher.group(2);
 
-			javaTermContent = StringUtil.replace(
-				javaTermContent, setGroupPermissionsMatcher.group(0),
-				modelPermissionsImplementation);
+			if (hasSetGuestPermissions) {
+				guestPermissions = setGuestPermissionsMatcher.group(2);
+
+				javaTermContent = StringUtil.removeSubstring(
+					javaTermContent, setGuestPermissionsMatcher.group(0));
+			}
 		}
 		else {
-			String modelPermissionsImplementation =
-				_getModelPermissionsImplementation(
-					"new String[0]", setGuestPermissionsMatcher.group(2),
-					SourceUtil.getIndent(setGuestPermissionsMatcher.group(0)),
-					setGuestPermissionsMatcher.group(1));
-
-			javaTermContent = StringUtil.replace(
-				javaTermContent, setGuestPermissionsMatcher.group(0),
-				modelPermissionsImplementation);
+			oldSub = setGuestPermissionsMatcher.group(0);
+			serviceContext = setGuestPermissionsMatcher.group(1);
+			guestPermissions = setGuestPermissionsMatcher.group(2);
 		}
 
-		return javaTermContent;
+		return StringUtil.replace(
+			javaTermContent, oldSub,
+			_getModelPermissionsImplementation(
+				groupPermissions, guestPermissions,
+				SourceUtil.getIndent(oldSub), serviceContext));
 	}
 
 	private String _getModelPermissionsImplementation(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaUpgradeModelPermissionsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaUpgradeModelPermissionsCheck.java
@@ -21,6 +21,7 @@ import com.liferay.source.formatter.check.util.SourceUtil;
 import com.liferay.source.formatter.parser.JavaTerm;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -55,14 +56,14 @@ public class JavaUpgradeModelPermissionsCheck extends BaseJavaTermCheck {
 		boolean hasSetGuestPermissions = false;
 
 		if (setGroupPermissionsMatcher.find()) {
-			hasSetGroupPermissions = _hasClassName(
-				"ServiceContext", javaTermContent, fileContent,
+			hasSetGroupPermissions = _isServiceContextMethodCall(
+				javaTermContent, fileContent,
 				setGroupPermissionsMatcher.group(1));
 		}
 
 		if (setGuestPermissionsMatcher.find()) {
-			hasSetGuestPermissions = _hasClassName(
-				"ServiceContext", javaTermContent, fileContent,
+			hasSetGuestPermissions = _isServiceContextMethodCall(
+				javaTermContent, fileContent,
 				setGuestPermissionsMatcher.group(1));
 		}
 
@@ -207,17 +208,12 @@ public class JavaUpgradeModelPermissionsCheck extends BaseJavaTermCheck {
 		return sb.toString();
 	}
 
-	private boolean _hasClassName(
-		String className, String content, String fileContent, String variable) {
+	private boolean _isServiceContextMethodCall(
+		String methodCall, String fileContent, String variableName) {
 
-		String variableTypeName = getVariableTypeName(
-			content, fileContent, variable);
-
-		if (variableTypeName.equals(className)) {
-			return true;
-		}
-
-		return false;
+		return Objects.equals(
+			getVariableTypeName(methodCall, fileContent, variableName),
+			"ServiceContext");
 	}
 
 	private static final Pattern _setGroupPermissionsPattern = Pattern.compile(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaUpgradeModelPermissionsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaUpgradeModelPermissionsCheck.java
@@ -1,0 +1,228 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.check;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.source.formatter.check.util.SourceUtil;
+import com.liferay.source.formatter.parser.JavaTerm;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Michael Cavalcanti
+ */
+public class JavaUpgradeModelPermissionsCheck extends BaseJavaTermCheck {
+
+	@Override
+	protected String doProcess(
+			String fileName, String absolutePath, JavaTerm javaTerm,
+			String fileContent)
+		throws Exception {
+
+		List<String> importNames = javaTerm.getImportNames();
+
+		String javaTermContent = javaTerm.getContent();
+
+		if (!importNames.contains(
+				"com.liferay.portal.kernel.service.ServiceContext")) {
+
+			return javaTermContent;
+		}
+
+		Matcher setGroupPermissionsMatcher =
+			_setGroupPermissionsPattern.matcher(javaTermContent);
+
+		Matcher setGuestPermissionsMatcher =
+			_setGuestPermissionsPattern.matcher(javaTermContent);
+
+		boolean hasSetGroupPermissions = false;
+		boolean hasSetGuestPermissions = false;
+
+		if (setGroupPermissionsMatcher.find()) {
+			hasSetGroupPermissions = _hasClassName(
+				"ServiceContext", javaTermContent, fileContent,
+				setGroupPermissionsMatcher.group(1));
+		}
+
+		if (setGuestPermissionsMatcher.find()) {
+			hasSetGuestPermissions = _hasClassName(
+				"ServiceContext", javaTermContent, fileContent,
+				setGuestPermissionsMatcher.group(1));
+		}
+
+		if (hasSetGroupPermissions || hasSetGuestPermissions) {
+			if (javaTerm.isJavaClass()) {
+				return _addImports(fileContent, javaTermContent);
+			}
+
+			return _formatSetGroupAndGuestPermissions(
+				hasSetGroupPermissions, hasSetGuestPermissions,
+				setGroupPermissionsMatcher, setGuestPermissionsMatcher,
+				javaTermContent);
+		}
+
+		return javaTermContent;
+	}
+
+	@Override
+	protected String[] getCheckableJavaTermNames() {
+		return new String[] {JAVA_CLASS, JAVA_METHOD};
+	}
+
+	private String _addImports(String fileContent, String javaTermContent) {
+		if (!fileContent.contains(
+				"com.liferay.portal.kernel.service.permission." +
+					"ModelPermissions")) {
+
+			javaTermContent = StringBundler.concat(
+				"import com.liferay.portal.kernel.service.permission.",
+				"ModelPermissions;\n\n", javaTermContent);
+		}
+
+		if (!fileContent.contains(
+				"com.liferay.portal.kernel.model.role.RoleConstants")) {
+
+			javaTermContent = StringBundler.concat(
+				"import com.liferay.portal.kernel.model.role.",
+				"RoleConstants;\n\n", javaTermContent);
+		}
+
+		return javaTermContent;
+	}
+
+	private String _formatSetGroupAndGuestPermissions(
+		boolean hasSetGroupPermissions, boolean hasSetGuestPermissions,
+		Matcher setGroupPermissionsMatcher, Matcher setGuestPermissionsMatcher,
+		String javaTermContent) {
+
+		if (hasSetGroupPermissions && hasSetGuestPermissions) {
+			String modelPermissionsImplementation =
+				_getModelPermissionsImplementation(
+					setGroupPermissionsMatcher.group(2),
+					setGuestPermissionsMatcher.group(2),
+					SourceUtil.getIndent(setGroupPermissionsMatcher.group(0)),
+					setGroupPermissionsMatcher.group(1));
+
+			javaTermContent = StringUtil.replace(
+				javaTermContent,
+				new String[] {
+					setGroupPermissionsMatcher.group(0),
+					setGuestPermissionsMatcher.group(0)
+				},
+				new String[] {
+					modelPermissionsImplementation, StringPool.BLANK
+				});
+		}
+		else if (hasSetGroupPermissions) {
+			String modelPermissionsImplementation =
+				_getModelPermissionsImplementation(
+					setGroupPermissionsMatcher.group(2), "new String[0]",
+					SourceUtil.getIndent(setGroupPermissionsMatcher.group(0)),
+					setGroupPermissionsMatcher.group(1));
+
+			javaTermContent = StringUtil.replace(
+				javaTermContent, setGroupPermissionsMatcher.group(0),
+				modelPermissionsImplementation);
+		}
+		else {
+			String modelPermissionsImplementation =
+				_getModelPermissionsImplementation(
+					"new String[0]", setGuestPermissionsMatcher.group(2),
+					SourceUtil.getIndent(setGuestPermissionsMatcher.group(0)),
+					setGuestPermissionsMatcher.group(1));
+
+			javaTermContent = StringUtil.replace(
+				javaTermContent, setGuestPermissionsMatcher.group(0),
+				modelPermissionsImplementation);
+		}
+
+		return javaTermContent;
+	}
+
+	private String _getModelPermissionsImplementation(
+		String groupPermissions, String guestPermissions, String indent,
+		String serviceContext) {
+
+		StringBundler sb = new StringBundler(35);
+
+		sb.append(StringPool.NEW_LINE);
+		sb.append(indent);
+		sb.append("ModelPermissions modelPermissions = ");
+		sb.append(serviceContext);
+		sb.append(".getModelPermissions();\n\n");
+		sb.append(indent);
+		sb.append("if (modelPermissions == null) {\n");
+		sb.append(indent);
+		sb.append("\tmodelPermissions = ModelPermissionsFactory.create(");
+		sb.append(groupPermissions);
+		sb.append(StringPool.COMMA_AND_SPACE);
+		sb.append(guestPermissions);
+		sb.append(");\n");
+		sb.append(indent);
+		sb.append("}\n");
+		sb.append(indent);
+		sb.append("else {");
+
+		if (!groupPermissions.equals("new String[0]")) {
+			sb.append(StringPool.NEW_LINE);
+			sb.append(indent);
+			sb.append("\tmodelPermissions.addRolePermissions(");
+			sb.append("RoleConstants.PLACEHOLDER_DEFAULT_GROUP_ROLE, ");
+			sb.append(groupPermissions);
+			sb.append(");");
+		}
+
+		if (!guestPermissions.equals("new String[0]")) {
+			sb.append(StringPool.NEW_LINE);
+			sb.append(indent);
+			sb.append("\tmodelPermissions.addRolePermissions(");
+			sb.append("RoleConstants.GUEST, ");
+			sb.append(guestPermissions);
+			sb.append(");");
+		}
+
+		sb.append(StringPool.NEW_LINE);
+		sb.append(indent);
+		sb.append("}\n\n");
+		sb.append(indent);
+		sb.append(serviceContext);
+		sb.append(".setModelPermissions(modelPermissions);");
+
+		return sb.toString();
+	}
+
+	private boolean _hasClassName(
+		String className, String content, String fileContent, String variable) {
+
+		String variableTypeName = getVariableTypeName(
+			content, fileContent, variable);
+
+		if (variableTypeName.equals(className)) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private static final Pattern _setGroupPermissionsPattern = Pattern.compile(
+		"\\t*(\\w+)\\.setGroupPermissions\\(\\s*(\\w+)\\s*\\);");
+	private static final Pattern _setGuestPermissionsPattern = Pattern.compile(
+		"\\t*(\\w+)\\.setGuestPermissions\\(\\s*(\\w+)\\s*\\);");
+
+}

--- a/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
@@ -279,6 +279,7 @@ JavaUpgradeConnectionCheck | [Bug Prevention](bug_prevention_checks.markdown#bug
 [JavaUpgradeDropTableCheck](check/java_upgrade_drop_table_check.markdown#javaupgradedroptablecheck) | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .java | Finds cases where `DROP_TABLE_IF_EXISTS` should be used (instead of `drop table if exists`). |
 JavaUpgradeEmptyLinesCheck | [Styling](styling_checks.markdown#styling-checks) | .java | Finds missing and unnecessary empty lines in Upgrade classes. |
 [JavaUpgradeIndexCheck](check/java_upgrade_index_check.markdown#javaupgradeindexcheck) | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .java | Finds cases where the service builder indexes are updated manually in Upgrade classes. This is not needed because Liferay takes care of it. |
+JavaUpgradeModelPermissionsCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | .java | Replace setGroupPermissions and setGuestPermissions by new implementation |
 JavaUpgradeProcessFactoryCheck | [Styling](styling_checks.markdown#styling-checks) | .java | Sorts and groups method calls. |
 JavaUpgradeServiceTrackerListCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | .java | Replace the number of generic type arguments in ServiceTrackerList |
 JavaUpgradeVersionCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .java | Verifies that the correct upgrade versions are used in classes that implement `UpgradeStepRegistrator`. |

--- a/modules/util/source-formatter/src/main/resources/documentation/java_source_processor_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/java_source_processor_checks.markdown
@@ -165,6 +165,7 @@ JavaUpgradeConnectionCheck | [Bug Prevention](bug_prevention_checks.markdown#bug
 [JavaUpgradeDropTableCheck](check/java_upgrade_drop_table_check.markdown#javaupgradedroptablecheck) | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Finds cases where `DROP_TABLE_IF_EXISTS` should be used (instead of `drop table if exists`). |
 JavaUpgradeEmptyLinesCheck | [Styling](styling_checks.markdown#styling-checks) | Finds missing and unnecessary empty lines in Upgrade classes. |
 [JavaUpgradeIndexCheck](check/java_upgrade_index_check.markdown#javaupgradeindexcheck) | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Finds cases where the service builder indexes are updated manually in Upgrade classes. This is not needed because Liferay takes care of it. |
+JavaUpgradeModelPermissionsCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | Replace setGroupPermissions and setGuestPermissions by new implementation |
 JavaUpgradeProcessFactoryCheck | [Styling](styling_checks.markdown#styling-checks) | Sorts and groups method calls. |
 JavaUpgradeServiceTrackerListCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | Replace the number of generic type arguments in ServiceTrackerList |
 JavaUpgradeVersionCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Verifies that the correct upgrade versions are used in classes that implement `UpgradeStepRegistrator`. |

--- a/modules/util/source-formatter/src/main/resources/documentation/upgrade_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/upgrade_checks.markdown
@@ -4,6 +4,7 @@ Check | File Extensions | Description
 ----- | --------------- | -----------
 [GradleUpgradeReleaseDXPCheck](check/gradle_upgrade_release_dxp_check.markdown#gradleupgradereleasedxpcheck) | .gradle | Remove and replaced dependencies in `build.gradle` that are already in `release.dxp.api` with `released.dxp.api` dependency. |
 JSPUpgradeRemovedTagsCheck | .jsp, .jspf, .jspx, .tag, .tpl or .vm | Finds removed tags when upgrading. |
+JavaUpgradeModelPermissionsCheck | .java | Replace setGroupPermissions and setGuestPermissions by new implementation |
 JavaUpgradeServiceTrackerListCheck | .java | Replace the number of generic type arguments in ServiceTrackerList |
 [PropertiesUpgradeLiferayPluginPackageFileCheck](check/properties_upgrade_liferay_plugin_package_file_check.markdown#propertiesupgradeliferaypluginpackagefilecheck) | .eslintignore, .prettierignore or .properties | Performs several upgrade checks in `liferay-plugin-package.properties` file. |
 PropertiesUpgradeLiferayPluginPackageLiferayVersionsCheck | .eslintignore, .prettierignore or .properties | Validates and upgrades the version in `liferay-plugin-package.properties` file. |

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -602,6 +602,10 @@
 			<category name="Styling" />
 			<description name="Applies rules to enforce consistency in code style." />
 		</check>
+		<check name="JavaUpgradeModelPermissionsCheck">
+			<category name="Upgrade" />
+			<description name="Replace setGroupPermissions and setGuestPermissions by new implementation" />
+		</check>
 		<check name="JavaUpgradeServiceTrackerListCheck">
 			<category name="Upgrade" />
 			<description name="Replace the number of generic type arguments in ServiceTrackerList" />

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/UpgradeSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/UpgradeSourceProcessorTest.java
@@ -69,6 +69,11 @@ public class UpgradeSourceProcessorTest extends BaseSourceProcessorTestCase {
 	}
 
 	@Test
+	public void testUpgradeJavaModelPermissionsCheck() throws Exception {
+		test("upgrade/UpgradeJavaModelPermissionsCheck.testjava");
+	}
+
+	@Test
 	public void testUpgradeJavaServiceReferenceAnnotationCheck()
 		throws Exception {
 

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeJavaModelPermissionsCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeJavaModelPermissionsCheck.testjava
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import com.liferay.portal.kernel.service.ServiceContext;
+
+import com.liferay.portal.kernel.model.role.RoleConstants;
+
+import com.liferay.portal.kernel.service.permission.ModelPermissions;
+
+/**
+ * @author Michael Cavalcanti
+ */
+@Component(immediate = true)
+public class UpgradeJavaModelPermissionsCheck {
+
+	@Override
+	public App addOrUpdate() throws IOException, PortalException {
+		ServiceContext serviceContext;
+
+		String[] groupPermissions = {"VIEW"};
+		String[] guestPermissions = {"VIEW"};
+
+		serviceContext.setAddGroupPermissions(true);
+		serviceContext.setDeriveDefaultPermissions(true);
+
+		ModelPermissions modelPermissions = serviceContext.getModelPermissions();
+
+		if (modelPermissions == null) {
+			modelPermissions = ModelPermissionsFactory.create(groupPermissions, guestPermissions);
+		}
+		else {
+			modelPermissions.addRolePermissions(RoleConstants.PLACEHOLDER_DEFAULT_GROUP_ROLE, groupPermissions);
+			modelPermissions.addRolePermissions(RoleConstants.GUEST, guestPermissions);
+		}
+
+		serviceContext.setModelPermissions(modelPermissions);
+
+	}
+
+	@Override
+	public App addOrUpdate2() throws IOException, PortalException {
+		ServiceContext serviceContext;
+
+		String[] groupPermissions = {"VIEW"};
+
+		serviceContext.setAddGroupPermissions(true);
+		serviceContext.setDeriveDefaultPermissions(true);
+
+		ModelPermissions modelPermissions = serviceContext.getModelPermissions();
+
+		if (modelPermissions == null) {
+			modelPermissions = ModelPermissionsFactory.create(groupPermissions, new String[0]);
+		}
+		else {
+			modelPermissions.addRolePermissions(RoleConstants.PLACEHOLDER_DEFAULT_GROUP_ROLE, groupPermissions);
+		}
+
+		serviceContext.setModelPermissions(modelPermissions);
+	}
+
+	@Override
+	public App addOrUpdate3() throws IOException, PortalException {
+		ServiceContext serviceContext2;
+
+		String[] guestPermissions = {"VIEW"};
+
+		serviceContext2.setAddGroupPermissions(true);
+		serviceContext2.setDeriveDefaultPermissions(true);
+
+		ModelPermissions modelPermissions = serviceContext2.getModelPermissions();
+
+		if (modelPermissions == null) {
+			modelPermissions = ModelPermissionsFactory.create(new String[0], guestPermissions);
+		}
+		else {
+			modelPermissions.addRolePermissions(RoleConstants.GUEST, guestPermissions);
+		}
+
+		serviceContext2.setModelPermissions(modelPermissions);
+	}
+
+	@Override
+	public App addOrUpdate4() throws IOException, PortalException {
+		ServiceContext serviceContext2;
+
+		serviceContext2.setAddGroupPermissions(true);
+		serviceContext2.setDeriveDefaultPermissions(true);
+	}
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeJavaModelPermissionsCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeJavaModelPermissionsCheck.testjava
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import com.liferay.portal.kernel.service.ServiceContext;
+
+/**
+ * @author Michael Cavalcanti
+ */
+@Component(immediate = true)
+public class UpgradeJavaModelPermissionsCheck {
+
+	@Override
+	public App addOrUpdate() throws IOException, PortalException {
+		ServiceContext serviceContext;
+
+		String[] groupPermissions = {"VIEW"};
+		String[] guestPermissions = {"VIEW"};
+
+		serviceContext.setAddGroupPermissions(true);
+		serviceContext.setDeriveDefaultPermissions(true);
+		serviceContext.setGroupPermissions(groupPermissions);
+		serviceContext.setGuestPermissions(guestPermissions);
+	}
+
+	@Override
+	public App addOrUpdate2() throws IOException, PortalException {
+		ServiceContext serviceContext;
+
+		String[] groupPermissions = {"VIEW"};
+
+		serviceContext.setAddGroupPermissions(true);
+		serviceContext.setDeriveDefaultPermissions(true);
+		serviceContext.setGroupPermissions(groupPermissions);
+	}
+
+	@Override
+	public App addOrUpdate3() throws IOException, PortalException {
+		ServiceContext serviceContext2;
+
+		String[] guestPermissions = {"VIEW"};
+
+		serviceContext2.setAddGroupPermissions(true);
+		serviceContext2.setDeriveDefaultPermissions(true);
+		serviceContext2.setGuestPermissions(guestPermissions);
+	}
+
+	@Override
+	public App addOrUpdate4() throws IOException, PortalException {
+		ServiceContext serviceContext2;
+
+		serviceContext2.setAddGroupPermissions(true);
+		serviceContext2.setDeriveDefaultPermissions(true);
+	}
+
+}


### PR DESCRIPTION
Hi, Kevin.
If I understand Brian's questions correctly, I changed the test files by adding the groupPermissions and guestPermissions variables in each method that was using them, I also changed the name of the variable from sc to serviceContext2, I think it is necessary to explain that the variable has a different name because we want to test if the automation is correctly identifying with which variable it is manipulating.

Ticket: [LPS-186054](https://liferay.atlassian.net/browse/LPS-186054).