### PR TITLE
LPS-189524 The java classes that extends SchedulerEntryImpl need to have the super() constructor filled with parameters

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaUpgradeSchedulerEntryImplConstructorCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaUpgradeSchedulerEntryImplConstructorCheck.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.check;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringUtil;
+import com.liferay.source.formatter.parser.JavaClass;
+import com.liferay.source.formatter.parser.JavaConstructor;
+import com.liferay.source.formatter.parser.JavaParameter;
+import com.liferay.source.formatter.parser.JavaSignature;
+import com.liferay.source.formatter.parser.JavaTerm;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * @author Michael Cavalcanti
+ */
+public class JavaUpgradeSchedulerEntryImplConstructorCheck
+	extends BaseJavaTermCheck {
+
+	@Override
+	protected String doProcess(
+			String fileName, String absolutePath, JavaTerm javaTerm,
+			String fileContent)
+		throws Exception {
+
+		JavaClass javaClass = javaTerm.getParentJavaClass();
+
+		List<String> extendedClassNames = javaClass.getExtendedClassNames();
+
+		if (!extendedClassNames.contains("SchedulerEntryImpl")) {
+			return javaTerm.getContent();
+		}
+
+		return _formatConstructor((JavaConstructor)javaTerm);
+	}
+
+	@Override
+	protected String[] getCheckableJavaTermNames() {
+		return new String[] {JAVA_CONSTRUCTOR};
+	}
+
+	private String _formatConstructor(JavaConstructor javaConstructor) {
+		String content = javaConstructor.getContent();
+
+		if (!content.contains("super();")) {
+			return content;
+		}
+
+		String newSuperMethodCall = "super(\"\", null, \"\");";
+
+		JavaSignature javaSignature = javaConstructor.getSignature();
+
+		for (JavaParameter javaParameter : javaSignature.getParameters()) {
+			if (Objects.equals(
+					javaParameter.getParameterType(), "SchedulerEntryImpl")) {
+
+				newSuperMethodCall = _getNewSuperImplementation(
+					javaParameter.getParameterName());
+
+				break;
+			}
+		}
+
+		return StringUtil.replace(content, "super();", newSuperMethodCall);
+	}
+
+	private String _getNewSuperImplementation(String parameterName) {
+		StringBundler sb = new StringBundler(7);
+
+		sb.append("super(");
+		sb.append(parameterName);
+		sb.append(".getEventListenerClass(), ");
+		sb.append(parameterName);
+		sb.append(".getTrigger(), ");
+		sb.append(parameterName);
+		sb.append(".getDescription());");
+
+		return sb.toString();
+	}
+
+}

--- a/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
@@ -282,6 +282,7 @@ JavaUpgradeEmptyLinesCheck | [Styling](styling_checks.markdown#styling-checks) |
 JavaUpgradeModelPermissionsCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | .java | Replace setGroupPermissions and setGuestPermissions by new implementation |
 JavaUpgradeOnAfterUpdateParameterCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | .java | Add new parameter in method onAfterUpdate for classes extending the BaseModelListener |
 JavaUpgradeProcessFactoryCheck | [Styling](styling_checks.markdown#styling-checks) | .java | Sorts and groups method calls. |
+JavaUpgradeSchedulerEntryImplConstructorCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | .java | Replace constructors that use the empty constructor of the SchedulerEntryImpl class. |
 JavaUpgradeServiceTrackerListCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | .java | Replace the number of generic type arguments in ServiceTrackerList |
 JavaUpgradeVersionCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .java | Verifies that the correct upgrade versions are used in classes that implement `UpgradeStepRegistrator`. |
 JavaVariableTypeCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .java | Performs several checks on the modifiers on variables. |

--- a/modules/util/source-formatter/src/main/resources/documentation/java_source_processor_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/java_source_processor_checks.markdown
@@ -168,6 +168,7 @@ JavaUpgradeEmptyLinesCheck | [Styling](styling_checks.markdown#styling-checks) |
 JavaUpgradeModelPermissionsCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | Replace setGroupPermissions and setGuestPermissions by new implementation |
 JavaUpgradeOnAfterUpdateParameterCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | Add new parameter in method onAfterUpdate for classes extending the BaseModelListener |
 JavaUpgradeProcessFactoryCheck | [Styling](styling_checks.markdown#styling-checks) | Sorts and groups method calls. |
+JavaUpgradeSchedulerEntryImplConstructorCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | Replace constructors that use the empty constructor of the SchedulerEntryImpl class. |
 JavaUpgradeServiceTrackerListCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | Replace the number of generic type arguments in ServiceTrackerList |
 JavaUpgradeVersionCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Verifies that the correct upgrade versions are used in classes that implement `UpgradeStepRegistrator`. |
 JavaVariableTypeCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Performs several checks on the modifiers on variables. |

--- a/modules/util/source-formatter/src/main/resources/documentation/upgrade_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/upgrade_checks.markdown
@@ -6,6 +6,7 @@ Check | File Extensions | Description
 JSPUpgradeRemovedTagsCheck | .jsp, .jspf, .jspx, .tag, .tpl or .vm | Finds removed tags when upgrading. |
 JavaUpgradeModelPermissionsCheck | .java | Replace setGroupPermissions and setGuestPermissions by new implementation |
 JavaUpgradeOnAfterUpdateParameterCheck | .java | Add new parameter in method onAfterUpdate for classes extending the BaseModelListener |
+JavaUpgradeSchedulerEntryImplConstructorCheck | .java | Replace constructors that use the empty constructor of the SchedulerEntryImpl class. |
 JavaUpgradeServiceTrackerListCheck | .java | Replace the number of generic type arguments in ServiceTrackerList |
 [PropertiesUpgradeLiferayPluginPackageFileCheck](check/properties_upgrade_liferay_plugin_package_file_check.markdown#propertiesupgradeliferaypluginpackagefilecheck) | .eslintignore, .prettierignore or .properties | Performs several upgrade checks in `liferay-plugin-package.properties` file. |
 PropertiesUpgradeLiferayPluginPackageLiferayVersionsCheck | .eslintignore, .prettierignore or .properties | Validates and upgrades the version in `liferay-plugin-package.properties` file. |

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -610,6 +610,10 @@
 			<category name="Upgrade" />
 			<description name="Add new parameter in method onAfterUpdate for classes extending the BaseModelListener" />
 		</check>
+		<check name="JavaUpgradeSchedulerEntryImplConstructorCheck">
+			<category name="Upgrade" />
+			<description name="Replace constructors that use the empty constructor of the SchedulerEntryImpl class." />
+		</check>
 		<check name="JavaUpgradeServiceTrackerListCheck">
 			<category name="Upgrade" />
 			<description name="Replace the number of generic type arguments in ServiceTrackerList" />

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/UpgradeSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/UpgradeSourceProcessorTest.java
@@ -134,6 +134,13 @@ public class UpgradeSourceProcessorTest extends BaseSourceProcessorTestCase {
 	}
 
 	@Test
+	public void testUpgradeJavaSchedulerEntryImplConstructorCheck()
+		throws Exception {
+
+		test("upgrade/UpgradeJavaSchedulerEntryImplConstructorCheck.testjava");
+	}
+
+	@Test
 	public void testUpgradeJavaServiceReferenceAnnotationCheck()
 		throws Exception {
 

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeJavaSchedulerEntryImplConstructorCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeJavaSchedulerEntryImplConstructorCheck.testjava
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import com.liferay.portal.kernel.scheduler.SchedulerEntryImpl;
+import com.liferay.portal.kernel.scheduler.TriggerConfiguration;
+
+/**
+ * @author Michael Cavalcanti
+ */
+public class UpgradeJavaSchedulerEntryImplConstructorCheck
+		extends SchedulerEntryImpl {
+
+	public UpgradeJavaSchedulerEntryImplConstructorCheck() {
+
+		super("", null, "");
+	}
+
+	public UpgradeJavaSchedulerEntryImplConstructorCheck(
+			SchedulerEntryImpl schedulerEntry) {
+
+		super(schedulerEntry.getEventListenerClass(), schedulerEntry.getTrigger(), schedulerEntry.getDescription());
+	}
+
+	public UpgradeJavaSchedulerEntryImplConstructorCheck(
+			String eventListenerClass, TriggerConfiguration triggerConfiguration,
+			String description) {
+
+		super(eventListenerClass, triggerConfiguration, description);
+	}
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeJavaSchedulerEntryImplConstructorCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeJavaSchedulerEntryImplConstructorCheck.testjava
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import com.liferay.portal.kernel.scheduler.SchedulerEntryImpl;
+import com.liferay.portal.kernel.scheduler.TriggerConfiguration;
+
+/**
+ * @author Michael Cavalcanti
+ */
+public class UpgradeJavaSchedulerEntryImplConstructorCheck
+		extends SchedulerEntryImpl {
+
+	public UpgradeJavaSchedulerEntryImplConstructorCheck() {
+
+		super();
+	}
+
+	public UpgradeJavaSchedulerEntryImplConstructorCheck(
+			SchedulerEntryImpl schedulerEntry) {
+
+		super();
+	}
+
+	public UpgradeJavaSchedulerEntryImplConstructorCheck(
+			String eventListenerClass, TriggerConfiguration triggerConfiguration,
+			String description) {
+
+		super(eventListenerClass, triggerConfiguration, description);
+	}
+
+}


### PR DESCRIPTION
Hi @kevhlee.
This check is about removing the empty constructor for those who extend from the SchedulerEntryImpl class, two implementation possibilities have been added.
Ticket: [LPS-189524](https://liferay.atlassian.net/browse/LPS-189524) 