### PR TITLE
LPS-189971

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
@@ -78,7 +78,7 @@ public class JavaClassParser {
 			StringBundler.concat(
 				"\n(public\\s+)?(abstract\\s+)?(final\\s+)?@?",
 				"(class|enum|interface)\\s+", className,
-				"([<|\\s][^\\{]*)\\{"));
+				"([<|\\s]?[^\\{]*)\\{"));
 
 		Matcher matcher = pattern.matcher(content);
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
@@ -94,7 +94,12 @@ public class JavaClassParser {
 			y = content.lastIndexOf("\n\n", y - 1);
 
 			if (y == -1) {
-				throw new ParseException("Parsing error");
+				y = x + 1;
+				y = content.lastIndexOf("\r\n", y - 1);
+
+				if (y == -1) {
+					throw new ParseException("Parsing error");
+				}
 			}
 
 			if (ToolsUtil.getLevel(content.substring(y, x)) == 0) {
@@ -238,7 +243,7 @@ public class JavaClassParser {
 		while (true) {
 			String line = SourceUtil.getLine(classContent, lineNumber);
 
-			if (line.endsWith("*/")) {
+			if (line.endsWith("*/") || line.endsWith("*/\r")) {
 				return lineNumber;
 			}
 
@@ -490,7 +495,7 @@ public class JavaClassParser {
 			while (true) {
 				String line = SourceUtil.getLine(classContent, ++lineNumber);
 
-				if (line.endsWith("*/")) {
+				if (line.endsWith("*/") || line.endsWith("*/\r")) {
 					break;
 				}
 			}


### PR DESCRIPTION
During the upgrade of the chile bank, when we ran the automation we realized that it was not being executed correctly, when investigating the error we found that some of the client files were with the \r\n as a line break instead of the standard \n, the error was occurring when counting the comment lines in the JavaClassParser file, this PR is about an adjustment in the JavaClassParser file so that this does not occur again.
I look forward to your review and opinion.

Ticket: [LPS-189871](https://liferay.atlassian.net/browse/LPS-189871)

Note: This same problem is happening with UpgradeBNDIncludeResourceCheck and BNDSourceUtil, a fix is being developed.