### PR TITLE
LPS-189929

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BaseUpgradeCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BaseUpgradeCheck.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.check;
+
+import com.liferay.petra.string.CharPool;
+import com.liferay.source.formatter.check.util.JavaSourceUtil;
+
+/**
+ * @author Nícolas Moura
+ */
+public abstract class BaseUpgradeCheck extends BaseFileCheck {
+
+	protected String addNewImports(String newContent) {
+		String[] newImports = getNewImports();
+
+		if (newImports != null) {
+			newContent = JavaSourceUtil.addImports(newContent, newImports);
+		}
+
+		return newContent;
+	}
+
+	protected String afterFormat(
+		String fileName, String absolutePath, String content,
+		String newContent) {
+
+		return addNewImports(newContent);
+	}
+
+	@Override
+	protected String doProcess(
+			String fileName, String absolutePath, String content)
+		throws Exception {
+
+		if (!isValidExtension(fileName)) {
+			return content;
+		}
+
+		String newContent = format(fileName, absolutePath, content);
+
+		if (!content.equals(newContent)) {
+			newContent = afterFormat(
+				fileName, absolutePath, content, newContent);
+		}
+
+		return newContent;
+	}
+
+	protected abstract String format(
+			String fileName, String absolutePath, String content)
+		throws Exception;
+
+	protected String[] getNewImports() {
+		return null;
+	}
+
+	protected String[] getValidExtensions() {
+		return new String[] {"java"};
+	}
+
+	protected boolean isValidExtension(String fileName) {
+		for (String extension : getValidExtensions()) {
+			if (fileName.endsWith(CharPool.PERIOD + extension)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BaseUpgradeMatcherReplacementCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BaseUpgradeMatcherReplacementCheck.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.check;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Nícolas Moura
+ */
+public abstract class BaseUpgradeMatcherReplacementCheck
+	extends BaseUpgradeCheck {
+
+	protected String beforeFormatIteration(
+		String fileName, String absolutePath, String content) {
+
+		return content;
+	}
+
+	@Override
+	protected String format(
+		String fileName, String absolutePath, String content) {
+
+		String newContent = beforeFormatIteration(
+			fileName, absolutePath, content);
+
+		Matcher matcher = getPattern().matcher(content);
+
+		while (matcher.find()) {
+			newContent = formatIteration(content, newContent, matcher);
+		}
+
+		return newContent;
+	}
+
+	protected abstract String formatIteration(
+		String content, String newContent, Matcher matcher);
+
+	protected abstract Pattern getPattern();
+
+}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BaseUpgradeMatcherReplacementCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BaseUpgradeMatcherReplacementCheck.java
@@ -36,7 +36,9 @@ public abstract class BaseUpgradeMatcherReplacementCheck
 		String newContent = beforeFormatIteration(
 			fileName, absolutePath, content);
 
-		Matcher matcher = getPattern().matcher(content);
+		Pattern pattern = getPattern();
+
+		Matcher matcher = pattern.matcher(content);
 
 		while (matcher.find()) {
 			newContent = formatIteration(content, newContent, matcher);

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BaseUpgradeMatcherReplacementCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BaseUpgradeMatcherReplacementCheck.java
@@ -41,13 +41,13 @@ public abstract class BaseUpgradeMatcherReplacementCheck
 		Matcher matcher = pattern.matcher(content);
 
 		while (matcher.find()) {
-			newContent = formatIteration(content, newContent, matcher);
+			newContent = formatMatcherIteration(content, newContent, matcher);
 		}
 
 		return newContent;
 	}
 
-	protected abstract String formatIteration(
+	protected abstract String formatMatcherIteration(
 		String content, String newContent, Matcher matcher);
 
 	protected abstract Pattern getPattern();

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeGetImagePreviewURLMethodCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeGetImagePreviewURLMethodCheck.java
@@ -16,7 +16,6 @@ package com.liferay.source.formatter.check;
 
 import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.source.formatter.check.util.JavaSourceUtil;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -24,44 +23,48 @@ import java.util.regex.Pattern;
 /**
  * @author Tamyris Bernardo
  */
-public class UpgradeGetImagePreviewURLMethodCheck extends BaseFileCheck {
+public class UpgradeGetImagePreviewURLMethodCheck
+	extends BaseUpgradeMatcherReplacementCheck {
 
 	@Override
-	protected String doProcess(
-			String fileName, String absolutePath, String content)
-		throws Exception {
+	protected String afterFormat(
+		String fileName, String absolutePath, String content,
+		String newContent) {
 
-		if (!fileName.endsWith(".java") && !fileName.endsWith(".jsp")) {
-			return content;
-		}
-
-		boolean replaced = false;
-
-		Matcher getImagePreviewURLMatcher = _getImagePreviewURLPattern.matcher(
-			content);
-
-		while (getImagePreviewURLMatcher.find()) {
-			String methodCall = getImagePreviewURLMatcher.group();
-
-			content = StringUtil.replace(
-				content, methodCall,
-				StringUtil.replace(methodCall, "DLUtil", "_dlURLHelper"));
-
-			replaced = true;
-		}
-
-		if (fileName.endsWith(".java") && replaced) {
-			content = JavaSourceUtil.addImports(
-				content, "com.liferay.document.library.util.DLURLHelper");
-			content = StringUtil.replaceLast(
-				content, CharPool.CLOSE_CURLY_BRACE,
+		if (fileName.endsWith(".java")) {
+			newContent = addNewImports(newContent);
+			newContent = StringUtil.replaceLast(
+				newContent, CharPool.CLOSE_CURLY_BRACE,
 				"\t@Reference\n\tprivate DLURLHelper _dlURLHelper;\n\n}");
 		}
 
-		return content;
+		return newContent;
 	}
 
-	private static final Pattern _getImagePreviewURLPattern = Pattern.compile(
-		"DLUtil\\.\\s*getImagePreviewURL\\(");
+	@Override
+	protected String formatIteration(
+		String content, String newContent, Matcher matcher) {
+
+		String methodCall = matcher.group();
+
+		return StringUtil.replace(
+			newContent, methodCall,
+			StringUtil.replace(methodCall, "DLUtil", "_dlURLHelper"));
+	}
+
+	@Override
+	protected String[] getNewImports() {
+		return new String[] {"com.liferay.document.library.util.DLURLHelper"};
+	}
+
+	@Override
+	protected Pattern getPattern() {
+		return Pattern.compile("DLUtil\\.\\s*getImagePreviewURL\\(");
+	}
+
+	@Override
+	protected String[] getValidExtensions() {
+		return new String[] {"java", "jsp"};
+	}
 
 }

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeGetImagePreviewURLMethodCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeGetImagePreviewURLMethodCheck.java
@@ -42,7 +42,7 @@ public class UpgradeGetImagePreviewURLMethodCheck
 	}
 
 	@Override
-	protected String formatIteration(
+	protected String formatMatcherIteration(
 		String content, String newContent, Matcher matcher) {
 
 		String methodCall = matcher.group();

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaAddFDSTableSchemaFieldCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaAddFDSTableSchemaFieldCheck.java
@@ -27,16 +27,12 @@ import java.util.regex.Pattern;
 /**
  * @author Michael Cavalcanti
  */
-public class UpgradeJavaAddFDSTableSchemaFieldCheck extends BaseFileCheck {
+public class UpgradeJavaAddFDSTableSchemaFieldCheck extends BaseUpgradeCheck {
 
 	@Override
-	protected String doProcess(
+	protected String format(
 			String fileName, String absolutePath, String content)
 		throws Exception {
-
-		if (!fileName.endsWith(".java")) {
-			return content;
-		}
 
 		JavaClass javaClass = JavaClassParser.parseJavaClass(fileName, content);
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaAddFolderParameterCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaAddFolderParameterCheck.java
@@ -28,7 +28,7 @@ public class UpgradeJavaAddFolderParameterCheck
 	extends BaseUpgradeMatcherReplacementCheck {
 
 	@Override
-	protected String formatIteration(
+	protected String formatMatcherIteration(
 		String content, String newContent, Matcher matcher) {
 
 		String methodCall = JavaSourceUtil.getMethodCall(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaAddFolderParameterCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaAddFolderParameterCheck.java
@@ -14,7 +14,6 @@
 
 package com.liferay.source.formatter.check;
 
-import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.source.formatter.check.util.JavaSourceUtil;
 
@@ -25,55 +24,44 @@ import java.util.regex.Pattern;
 /**
  * @author Nícolas Moura
  */
-public class UpgradeJavaAddFolderParameterCheck extends BaseFileCheck {
+public class UpgradeJavaAddFolderParameterCheck
+	extends BaseUpgradeMatcherReplacementCheck {
 
 	@Override
-	protected String doProcess(
-			String fileName, String absolutePath, String content)
-		throws Exception {
+	protected String formatIteration(
+		String content, String newContent, Matcher matcher) {
 
-		String newContent = content;
+		String methodCall = JavaSourceUtil.getMethodCall(
+			content, matcher.start());
 
-		Matcher addFolderMatcher = _addFolderPattern.matcher(content);
+		List<String> parameterList = JavaSourceUtil.getParameterList(
+			methodCall);
 
-		while (addFolderMatcher.find()) {
-			String methodCall = JavaSourceUtil.getMethodCall(
-				content, addFolderMatcher.start());
+		if (parameterList.size() == 7) {
+			return newContent;
+		}
 
-			List<String> parameterList = JavaSourceUtil.getParameterList(
-				methodCall);
+		String variable = matcher.group(1);
 
-			if (parameterList.size() == 7) {
-				continue;
-			}
+		if (variable.equals("JournalFolderLocalServiceUtil")) {
+			return _addParameter(newContent, methodCall);
+		}
 
-			if (methodCall.contains("JournalFolderLocalServiceUtil")) {
-				newContent = _addParameter(newContent, methodCall);
+		String variableTypeName = getVariableTypeName(
+			newContent, newContent, variable);
 
-				continue;
-			}
+		if (variableTypeName.equals("JournalFolderService") ||
+			variableTypeName.equals("JournalFolderLocalService")) {
 
-			String variable = methodCall.substring(
-				0, methodCall.indexOf(CharPool.PERIOD));
-
-			Pattern variableDeclarationPattern = Pattern.compile(
-				"[A-Za-z_]+ " + variable);
-
-			Matcher variableDeclarationMatcher =
-				variableDeclarationPattern.matcher(content);
-
-			if (variableDeclarationMatcher.find()) {
-				String variableDeclaration = variableDeclarationMatcher.group();
-
-				if (variableDeclaration.contains("JournalFolderService") ||
-					variableDeclaration.contains("JournalFolderLocalService")) {
-
-					newContent = _addParameter(newContent, methodCall);
-				}
-			}
+			newContent = _addParameter(newContent, methodCall);
 		}
 
 		return newContent;
+	}
+
+	@Override
+	protected Pattern getPattern() {
+		return Pattern.compile("(\\w+)\\.addFolder\\(");
 	}
 
 	private String _addParameter(String content, String methodCall) {
@@ -81,8 +69,5 @@ public class UpgradeJavaAddFolderParameterCheck extends BaseFileCheck {
 			content, methodCall,
 			StringUtil.replace(methodCall, ".addFolder(", ".addFolder(null, "));
 	}
-
-	private static final Pattern _addFolderPattern = Pattern.compile(
-		"\\w+\\.addFolder\\(");
 
 }

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaAssetEntryAssetCategoriesCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaAssetEntryAssetCategoriesCheck.java
@@ -18,7 +18,6 @@ import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.source.formatter.check.util.JavaSourceUtil;
 import com.liferay.source.formatter.check.util.SourceUtil;
 
 import java.util.regex.Matcher;
@@ -27,36 +26,39 @@ import java.util.regex.Pattern;
 /**
  * @author Nícolas Moura
  */
-public class UpgradeJavaAssetEntryAssetCategoriesCheck extends BaseFileCheck {
+public class UpgradeJavaAssetEntryAssetCategoriesCheck
+	extends BaseUpgradeCheck {
 
 	@Override
-	protected String doProcess(
-			String fileName, String absolutePath, String content)
-		throws Exception {
+	protected String afterFormat(
+		String fileName, String absolutePath, String content,
+		String newContent) {
 
-		if (!fileName.endsWith(".java")) {
-			return content;
-		}
+		newContent = addNewImports(newContent);
+
+		return StringUtil.replaceLast(
+			newContent, CharPool.CLOSE_CURLY_BRACE,
+			"\n\t@Reference\n\tprivate " +
+				"AssetEntryAssetCategoryRelLocalService\n\t\t" +
+					"_assetEntryAssetCategoryRelLocalService;\n\n}");
+	}
+
+	@Override
+	protected String format(
+		String fileName, String absolutePath, String content) {
 
 		String newContent = _replaceAddOrDeleteAssetCategories(content);
 
-		newContent = _replaceAddOrDeleteAssetCategory(newContent);
+		return _replaceAddOrDeleteAssetCategory(newContent);
+	}
 
-		if (!content.equals(newContent)) {
-			newContent = JavaSourceUtil.addImports(
-				newContent,
-				"com.liferay.asset.entry.rel.service." +
-					"AssetEntryAssetCategoryRelLocalService",
-				"org.osgi.service.component.annotations.Reference");
-
-			newContent = StringUtil.replaceLast(
-				newContent, CharPool.CLOSE_CURLY_BRACE,
-				"\n\t@Reference\n\tprivate " +
-					"AssetEntryAssetCategoryRelLocalService\n\t\t" +
-						"_assetEntryAssetCategoryRelLocalService;\n\n}");
-		}
-
-		return newContent;
+	@Override
+	protected String[] getNewImports() {
+		return new String[] {
+			"com.liferay.asset.entry.rel.service." +
+				"AssetEntryAssetCategoryRelLocalService",
+			"org.osgi.service.component.annotations.Reference"
+		};
 	}
 
 	private String _replaceAddOrDeleteAssetCategories(String content) {

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaExtractTextMethodCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaExtractTextMethodCheck.java
@@ -40,7 +40,7 @@ public class UpgradeJavaExtractTextMethodCheck
 	}
 
 	@Override
-	protected String formatIteration(
+	protected String formatMatcherIteration(
 		String content, String newContent, Matcher matcher) {
 
 		String methodCall = JavaSourceUtil.getMethodCall(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaExtractTextMethodCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaExtractTextMethodCheck.java
@@ -24,49 +24,46 @@ import java.util.regex.Pattern;
 /**
  * @author Nícolas Moura
  */
-public class UpgradeJavaExtractTextMethodCheck extends BaseFileCheck {
+public class UpgradeJavaExtractTextMethodCheck
+	extends BaseUpgradeMatcherReplacementCheck {
 
 	@Override
-	protected String doProcess(
-			String fileName, String absolutePath, String content)
-		throws Exception {
+	protected String afterFormat(
+		String fileName, String absolutePath, String content,
+		String newContent) {
 
-		if (!fileName.endsWith(".java")) {
-			return content;
-		}
+		newContent = addNewImports(newContent);
 
-		String newContent = content;
-
-		boolean replaced = false;
-
-		Matcher extractTextMatcher = _extractTextPattern.matcher(content);
-
-		while (extractTextMatcher.find()) {
-			String methodCall = JavaSourceUtil.getMethodCall(
-				content, extractTextMatcher.start());
-
-			newContent = StringUtil.replace(
-				newContent, methodCall,
-				StringUtil.replace(
-					methodCall, "HtmlUtil.extractText(",
-					"_htmlParser.extractText("));
-
-			replaced = true;
-		}
-
-		if (replaced) {
-			newContent = JavaSourceUtil.addImports(
-				newContent, "com.liferay.portal.kernel.util.HtmlParser",
-				"org.osgi.service.component.annotations.Reference");
-			newContent = StringUtil.replaceLast(
-				newContent, CharPool.CLOSE_CURLY_BRACE,
-				"\n\t@Reference\n\tprivate HtmlParser _htmlParser;\n}");
-		}
-
-		return newContent;
+		return StringUtil.replaceLast(
+			newContent, CharPool.CLOSE_CURLY_BRACE,
+			"\n\t@Reference\n\tprivate HtmlParser _htmlParser;\n}");
 	}
 
-	private static final Pattern _extractTextPattern = Pattern.compile(
-		"HtmlUtil\\.extractText\\(");
+	@Override
+	protected String formatIteration(
+		String content, String newContent, Matcher matcher) {
+
+		String methodCall = JavaSourceUtil.getMethodCall(
+			content, matcher.start());
+
+		return StringUtil.replace(
+			newContent, methodCall,
+			StringUtil.replace(
+				methodCall, "HtmlUtil.extractText(",
+				"_htmlParser.extractText("));
+	}
+
+	@Override
+	protected String[] getNewImports() {
+		return new String[] {
+			"com.liferay.portal.kernel.util.HtmlParser",
+			"org.osgi.service.component.annotations.Reference"
+		};
+	}
+
+	@Override
+	protected Pattern getPattern() {
+		return Pattern.compile("HtmlUtil\\.extractText\\(");
+	}
 
 }

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaMultiVMPoolUtilCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaMultiVMPoolUtilCheck.java
@@ -16,7 +16,6 @@ package com.liferay.source.formatter.check;
 
 import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.source.formatter.check.util.JavaSourceUtil;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -24,23 +23,28 @@ import java.util.regex.Pattern;
 /**
  * @author Nícolas Moura
  */
-public class UpgradeJavaMultiVMPoolUtilCheck extends BaseFileCheck {
+public class UpgradeJavaMultiVMPoolUtilCheck
+	extends BaseUpgradeMatcherReplacementCheck {
 
 	@Override
-	protected String doProcess(
-			String fileName, String absolutePath, String content)
-		throws Exception {
+	protected String afterFormat(
+		String fileName, String absolutePath, String content,
+		String newContent) {
 
-		if (!fileName.endsWith(".java")) {
-			return content;
-		}
+		newContent = addNewImports(newContent);
+		newContent = StringUtil.replace(
+			newContent, "MultiVMPoolUtil.getPortalCache(",
+			_WARNING_CASE_TYPE + " _multiVMPool.getPortalCache(");
+		newContent = StringUtil.replaceLast(
+			newContent, CharPool.CLOSE_CURLY_BRACE,
+			"\n\t@Reference\n\tprivate MultiVMPool _multiVMPool;\n\n}");
 
-		if (content.contains(_MULTI_VM_POOL_UTIL_IMPORT)) {
-			content = StringUtil.replace(
-				content, _MULTI_VM_POOL_UTIL_IMPORT,
-				"import com.liferay.portal.kernel.cache.MultiVMPool;");
-			content = _replaceGetPortalCache(content);
-		}
+		return newContent;
+	}
+
+	@Override
+	protected String beforeFormatIteration(
+		String fileName, String absolutePath, String content) {
 
 		if (content.contains(_WARNING_CASE_TYPE)) {
 			addMessage(
@@ -49,33 +53,35 @@ public class UpgradeJavaMultiVMPoolUtilCheck extends BaseFileCheck {
 					"Replace 'TO_BE_REPLACED' with the correct type");
 		}
 
-		return content;
+		return StringUtil.replace(
+			content, _MULTI_VM_POOL_UTIL_IMPORT,
+			"import com.liferay.portal.kernel.cache.MultiVMPool;");
 	}
 
-	private String _replaceGetPortalCache(String content) {
-		content = JavaSourceUtil.addImports(
-			content, "org.osgi.service.component.annotations.Reference");
+	@Override
+	protected String formatIteration(
+		String content, String newContent, Matcher matcher) {
 
-		Matcher portalCacheMatcher = _getPortalCachePattern.matcher(content);
+		String newDeclaration = StringUtil.replace(
+			matcher.group(0), "MultiVMPoolUtil.getPortalCache(",
+			"(PortalCache" + matcher.group(1) +
+				") _multiVMPool.getPortalCache(");
 
-		while (portalCacheMatcher.find()) {
-			String newDeclaration = StringUtil.replace(
-				portalCacheMatcher.group(0), "MultiVMPoolUtil.getPortalCache(",
-				"(PortalCache" + portalCacheMatcher.group(1) +
-					") _multiVMPool.getPortalCache(");
+		return StringUtil.replace(newContent, matcher.group(0), newDeclaration);
+	}
 
-			content = StringUtil.replace(
-				content, portalCacheMatcher.group(0), newDeclaration);
-		}
+	@Override
+	protected String[] getNewImports() {
+		return new String[] {
+			"org.osgi.service.component.annotations.Reference"
+		};
+	}
 
-		content = StringUtil.replace(
-			content, "MultiVMPoolUtil.getPortalCache(",
-			_WARNING_CASE_TYPE + " _multiVMPool.getPortalCache(");
-		content = StringUtil.replaceLast(
-			content, CharPool.CLOSE_CURLY_BRACE,
-			"\n\t@Reference\n\tprivate MultiVMPool _multiVMPool;\n\n}");
-
-		return content;
+	@Override
+	protected Pattern getPattern() {
+		return Pattern.compile(
+			"PortalCache\\s*(<.+, +?.+>)\\s*\\w+" +
+				"\\s*=\\s*MultiVMPoolUtil\\.getPortalCache\\(");
 	}
 
 	private static final String _MULTI_VM_POOL_UTIL_IMPORT =
@@ -83,9 +89,5 @@ public class UpgradeJavaMultiVMPoolUtilCheck extends BaseFileCheck {
 
 	private static final String _WARNING_CASE_TYPE =
 		"(PortalCache<TO_BE_REPLACED, TO_BE_REPLACED>)";
-
-	private static final Pattern _getPortalCachePattern = Pattern.compile(
-		"PortalCache\\s*(<.+, +?.+>)\\s*\\w+\\s*=\\s*" +
-			"MultiVMPoolUtil\\.getPortalCache\\(");
 
 }

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaMultiVMPoolUtilCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaMultiVMPoolUtilCheck.java
@@ -59,7 +59,7 @@ public class UpgradeJavaMultiVMPoolUtilCheck
 	}
 
 	@Override
-	protected String formatIteration(
+	protected String formatMatcherIteration(
 		String content, String newContent, Matcher matcher) {
 
 		String newDeclaration = StringUtil.replace(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaServiceReferenceAnnotationCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaServiceReferenceAnnotationCheck.java
@@ -20,18 +20,25 @@ import com.liferay.source.formatter.check.util.JavaSourceUtil;
 /**
  * @author Tamyris Bernardo
  */
-public class UpgradeJavaServiceReferenceAnnotationCheck extends BaseFileCheck {
+public class UpgradeJavaServiceReferenceAnnotationCheck
+	extends BaseUpgradeCheck {
 
 	@Override
-	protected String doProcess(
+	protected String afterFormat(
+		String fileName, String absolutePath, String content,
+		String newContent) {
+
+		return StringUtil.replace(
+			newContent,
+			"import com.liferay.portal.spring.extender.service." +
+				"ServiceReference;",
+			"import org.osgi.service.component.annotations.Reference;");
+	}
+
+	@Override
+	protected String format(
 			String fileName, String absolutePath, String content)
 		throws Exception {
-
-		if (!fileName.endsWith(".java")) {
-			return content;
-		}
-
-		boolean replaced = false;
 
 		for (String annotationBlock :
 				JavaSourceUtil.getAnnotationsBlocks(content)) {
@@ -41,17 +48,7 @@ public class UpgradeJavaServiceReferenceAnnotationCheck extends BaseFileCheck {
 			if (annotationBlock.startsWith("@ServiceReference")) {
 				content = StringUtil.replace(
 					content, annotationBlock, "@Reference");
-
-				replaced = true;
 			}
-		}
-
-		if (replaced) {
-			content = StringUtil.replace(
-				content,
-				"import com.liferay.portal.spring.extender.service." +
-					"ServiceReference;",
-				"import org.osgi.service.component.annotations.Reference;");
 		}
 
 		return content;


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPS-189929

Hi Kevin!

This Pr it's about the new `BaseUpgradeMatcherReplacementCheck` base class that we discussed to reduce code repetition. I have applied to get examples of which structure for the base class would be good for covering most cases. 

I noticed that the following patterns were repeated in this type of check:

- The general structure of iterating substitution in a matcher, which generated the need for the class. But also:

- Checking the type of the correct file, and changing between the scope of the check.

- Some editing before formatting within the while itself.

- Some additional editing after the while formatting.

- The use of different Patterns.
- 
That's why the base class was created in this way reducing the repetition of code, as can be seen in the examples that I have already applied the base class. In addition to the code being more organizable and readable.

I have applied the aligned suggestions please take a look. Have created the `BaseUpgradeCheck` with all methods that need to be available for all checks and left the others at  `BaseUpgradeMatcherReplacementCheck`